### PR TITLE
Fix gameplay screen gating and refresh documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+.next/
+.DS_Store

--- a/CODE_REVIEW.md
+++ b/CODE_REVIEW.md
@@ -1,0 +1,20 @@
+# Code Review Findings
+
+## Suggested Tasks
+
+1. **Corrigir erro de digitação nas classes de estilo do container**  
+   As classes CSS e referências em JSX usam o nome `conteiner`, que parece um erro ortográfico consistente. Atualizar para `container` melhora a clareza e evita inconsistências em futuros estilos.  
+   Arquivos afetados: `app/jogo/TelaPrincipal.jsx`, `app/jogo/Styles/StyleTelaPrincipal.css`, `app/jogo/Styles/StyleRepGame.css`.  
+
+2. **Trocar operador bitwise por lógico na verificação da tela final**  
+   Em `RepGame.jsx`, a condição `!tela & !personagemCastelo` usa o operador bitwise `&`, o que pode produzir resultados incorretos quando os estados não são booleanos estritos. Substituir por `&&` garante a avaliação lógica adequada antes de renderizar a tela final.  
+   Arquivo afetado: `app/jogo/RepGame.jsx`.  
+
+3. **Alinhar a documentação com o nome atual do jogo**  
+   O README apresenta o projeto apenas como "Labirinto", enquanto a interface exibe "Stuart e o castelo perdido!". Atualizar o README para refletir o nome e contexto corretos evita confusão para novos colaboradores.  
+   Arquivos afetados: `README.md`.  
+
+4. **Adicionar teste para o recorte de visão do tabuleiro**  
+   `Tabuleiro.jsx` calcula dinamicamente uma janela de visão com base na posição do jogador. Um teste de unidade com React Testing Library poderia validar que o componente renderiza a quantidade esperada de células (p. ex., 17x17) e reposiciona corretamente ao mudar o jogador.  
+   Arquivo alvo: `app/jogo/Tabuleiro.jsx`.  
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,28 @@
-# Labirinto
+# Stuart e o Castelo Perdido
+
+Uma aventura em React/Next.js onde o jogador precisa encontrar a Excalibur e escapar do labirinto até alcançar o castelo. O projeto roda em Next.js 15 com componentes client-side para o tabuleiro do jogo.
+
+## Requisitos
+- Node.js 18+
+
+## Scripts disponíveis
+- `npm run dev` inicia o servidor de desenvolvimento.
+- `npm run build` gera o build de produção.
+- `npm run start` executa o build de produção.
+- `npm run lint` roda o linting com ESLint.
+
+## Como jogar
+1. Inicie o modo desenvolvimento com `npm run dev`.
+2. Acesse `http://localhost:3000`.
+3. Clique em **Entrar** para começar.
+4. Use as setas do teclado para mover Stuart pelo labirinto.
+5. Encontre a Excalibur antes de seguir para o castelo.
+
+## Estrutura principal
+- `app/jogo/TelaPrincipal.jsx`: controla o fluxo entre a tela inicial e o jogo.
+- `app/jogo/RepGame.jsx`: gerencia a lógica do jogo e o estado do jogador.
+- `app/jogo/Tabuleiro.jsx`: renderiza a porção visível do labirinto.
+- `app/jogo/Styles/`: contém os estilos CSS utilizados nas telas.
+
+## Próximos passos sugeridos
+Consulte `CODE_REVIEW.md` para uma lista de melhorias potenciais identificadas durante a revisão anterior.

--- a/app/jogo/RepGame.jsx
+++ b/app/jogo/RepGame.jsx
@@ -13,7 +13,7 @@ export default function RepGame() {
   }
 
   const [player, setPlayer] = useState([
-    numeroAleatorio(15,47),
+    numeroAleatorio(15, 47),
     numeroAleatorio(12, 47),
   ]);
   const [Objetivo, setObjetivo] = useState([
@@ -71,8 +71,10 @@ export default function RepGame() {
     ];
     if (!ObjetivoEncontrado && positionsArray.includes(true)) {
       window.confirm("Ache o objetivo primeiro! Encontre a Excalibur!");
-      setPlayer([numeroAleatorio(15,47),
-        numeroAleatorio(12, 47),]);
+      setPlayer([
+        numeroAleatorio(15, 47),
+        numeroAleatorio(12, 47),
+      ]);
       return;
     }
 
@@ -86,7 +88,7 @@ export default function RepGame() {
       } else if (e.key === "ArrowRight" && player[1] < 47) {
         setPlayer([player[0], player[1] + 1]);
       }
-      setMover(mover + 1);
+      setMover((prev) => prev + 1);
     }
 
     if (player[0] === Objetivo[0] && player[1] === Objetivo[1]) {
@@ -113,10 +115,14 @@ export default function RepGame() {
   }, [player, ObjetivoEncontrado, obst]);
 
   const reiniciarJogo = () => {
-    setPlayer([numeroAleatorio(15,47),
-    numeroAleatorio(12, 47)]);
-    setObjetivo([numeroAleatorio(15,47),
-      numeroAleatorio(12, 47),]);
+    setPlayer([
+      numeroAleatorio(15, 47),
+      numeroAleatorio(12, 47),
+    ]);
+    setObjetivo([
+      numeroAleatorio(15, 47),
+      numeroAleatorio(12, 47),
+    ]);
     setPersonagemCastelo(true);
     setObjetivoEncontrado(false);
     setMover(0);
@@ -124,7 +130,7 @@ export default function RepGame() {
 
   return (
     <div className="game">
-      {!tela & !personagemCastelo && (
+      {!tela && !personagemCastelo && (
         <div className="final">
           <h1 className="textoFinal1">Parabéns você chegou ao castelo!</h1>
           <button className="reiniciar" onClick={reiniciarJogo}>

--- a/app/jogo/Styles/StyleRepGame.css
+++ b/app/jogo/Styles/StyleRepGame.css
@@ -35,7 +35,7 @@ body {
 }
 
 
-.conteiner {
+.container {
   display: flex;
   flex-direction: column;
   justify-content: center;
@@ -50,7 +50,7 @@ body {
   animation: fadeIn 1s forwards;
 }
 
-.conteiner2 {
+.container2 {
   display: flex;
   flex-direction: column;
   justify-content: center;
@@ -204,7 +204,7 @@ body {
 }
 
 @media (max-width: 768px) {
-  .conteiner {
+  .container {
     width: 260px;
     height: 350px;
     padding: 20px;

--- a/app/jogo/Styles/StyleTelaPrincipal.css
+++ b/app/jogo/Styles/StyleTelaPrincipal.css
@@ -20,7 +20,7 @@ body {
 }
 
 /* Container principal */
-.conteiner {
+.container {
   position: relative;
   display: flex;
   flex-direction: column;
@@ -121,7 +121,7 @@ body {
   }
 }
 @media (max-width: 480px) {
-  .conteiner {
+  .container {
     width: 90%;
     max-width: 300px;
     min-height: auto;

--- a/app/jogo/TelaInicial.jsx
+++ b/app/jogo/TelaInicial.jsx
@@ -4,7 +4,7 @@ import "./Styles/StyleRepGame.css";
 
 export default function TelaInicial({ iniciarJogo }) {
   return (
-    <div className="conteiner2">
+    <div className="container2">
       <h1 className="tituloJogo">Stuart e o castelo perdido!</h1>
       <button className="linkjogo" onClick={iniciarJogo}>
         Entrar

--- a/app/jogo/TelaPrincipal.jsx
+++ b/app/jogo/TelaPrincipal.jsx
@@ -13,12 +13,12 @@ export default function TelaPrincipal() {
   return (
     <div>
       {!iniciarJogo ? (
-        <div className="conteiner">
-           <div className="personagem"></div>
-            <h3 className="tituloJogo">Stuart e o castelo perdido!</h3>
-            <button className="linkjogo" onClick={iniciar}>
-                Entrar
-            </button>
+        <div className="container">
+          <div className="personagem" />
+          <h3 className="tituloJogo">Stuart e o castelo perdido!</h3>
+          <button className="linkjogo" onClick={iniciar}>
+            Entrar
+          </button>
         </div>
       ) : (
         <RepGame />


### PR DESCRIPTION
## Summary
- add a CODE_REVIEW.md file outlining follow-up tasks for typos, bugs, docs, and tests
- create a .gitignore to exclude local build artifacts such as node_modules
- fix the final screen gating logic by using logical operators, ensuring the move counter increments correctly, and aligning JSX/CSS class names
- refresh the README to describe "Stuart e o Castelo Perdido" and document project usage

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e5ac7aaf2883249f0c3785cf24c15c