### PR TITLE
Enhance maze gameplay feedback and visuals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+.next/
+.DS_Store

--- a/CODE_REVIEW.md
+++ b/CODE_REVIEW.md
@@ -1,0 +1,20 @@
+# Code Review Findings
+
+## Suggested Tasks
+
+1. **Corrigir erro de digitação nas classes de estilo do container**  
+   As classes CSS e referências em JSX usam o nome `conteiner`, que parece um erro ortográfico consistente. Atualizar para `container` melhora a clareza e evita inconsistências em futuros estilos.  
+   Arquivos afetados: `app/jogo/TelaPrincipal.jsx`, `app/jogo/Styles/StyleTelaPrincipal.css`, `app/jogo/Styles/StyleRepGame.css`.  
+
+2. **Trocar operador bitwise por lógico na verificação da tela final**  
+   Em `RepGame.jsx`, a condição `!tela & !personagemCastelo` usa o operador bitwise `&`, o que pode produzir resultados incorretos quando os estados não são booleanos estritos. Substituir por `&&` garante a avaliação lógica adequada antes de renderizar a tela final.  
+   Arquivo afetado: `app/jogo/RepGame.jsx`.  
+
+3. **Alinhar a documentação com o nome atual do jogo**  
+   O README apresenta o projeto apenas como "Labirinto", enquanto a interface exibe "Stuart e o castelo perdido!". Atualizar o README para refletir o nome e contexto corretos evita confusão para novos colaboradores.  
+   Arquivos afetados: `README.md`.  
+
+4. **Adicionar teste para o recorte de visão do tabuleiro**  
+   `Tabuleiro.jsx` calcula dinamicamente uma janela de visão com base na posição do jogador. Um teste de unidade com React Testing Library poderia validar que o componente renderiza a quantidade esperada de células (p. ex., 17x17) e reposiciona corretamente ao mudar o jogador.  
+   Arquivo alvo: `app/jogo/Tabuleiro.jsx`.  
+

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ Uma aventura em React/Next.js onde o jogador precisa encontrar a Excalibur e esc
 ## Como jogar
 1. Inicie o modo desenvolvimento com `npm run dev`.
 2. Acesse `http://localhost:3000`.
-3. Clique em **Entrar** para começar.
+3. Clique em **Entrar** para começar e aproveite a nova interface com efeitos de luz.
 4. Use as setas do teclado para mover Stuart pelo labirinto.
-5. Encontre a Excalibur antes de seguir para o castelo.
+5. Colete a Excalibur brilhante, observando o painel de progresso, antes de seguir para o castelo.
 
 ## Estrutura principal
 - `app/jogo/TelaPrincipal.jsx`: controla o fluxo entre a tela inicial e o jogo.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,28 @@
-# Labirinto
+# Stuart e o Castelo Perdido
+
+Uma aventura em React/Next.js onde o jogador precisa encontrar a Excalibur e escapar do labirinto até alcançar o castelo. O projeto roda em Next.js 15 com componentes client-side para o tabuleiro do jogo.
+
+## Requisitos
+- Node.js 18+
+
+## Scripts disponíveis
+- `npm run dev` inicia o servidor de desenvolvimento.
+- `npm run build` gera o build de produção.
+- `npm run start` executa o build de produção.
+- `npm run lint` roda o linting com ESLint.
+
+## Como jogar
+1. Inicie o modo desenvolvimento com `npm run dev`.
+2. Acesse `http://localhost:3000`.
+3. Clique em **Entrar** para começar.
+4. Use as setas do teclado para mover Stuart pelo labirinto.
+5. Encontre a Excalibur antes de seguir para o castelo.
+
+## Estrutura principal
+- `app/jogo/TelaPrincipal.jsx`: controla o fluxo entre a tela inicial e o jogo.
+- `app/jogo/RepGame.jsx`: gerencia a lógica do jogo e o estado do jogador.
+- `app/jogo/Tabuleiro.jsx`: renderiza a porção visível do labirinto.
+- `app/jogo/Styles/`: contém os estilos CSS utilizados nas telas.
+
+## Próximos passos sugeridos
+Consulte `CODE_REVIEW.md` para uma lista de melhorias potenciais identificadas durante a revisão anterior.

--- a/app/jogo/RepGame.jsx
+++ b/app/jogo/RepGame.jsx
@@ -6,6 +6,7 @@ import Tabuleiro from "./Tabuleiro";
 import TelaInicial from "./TelaInicial";
 
 const LIMITES = { minX: 3, maxX: 47, minY: 10, maxY: 47 };
+const OBSTACLE_COUNT = 160;
 const CASTLE_TILES = [
   [4, 24],
   [4, 25],
@@ -24,7 +25,7 @@ const numeroAleatorio = (min, max) => {
 };
 
 const gerarObstaculos = () =>
-  Array.from({ length: 200 }, () => [
+  Array.from({ length: OBSTACLE_COUNT }, () => [
     numeroAleatorio(15, 47),
     numeroAleatorio(10, 47),
     numeroAleatorio(1, 2),
@@ -61,7 +62,91 @@ const gerarPosicaoLivre = (ocupadas = [], obstaculos = []) => {
     ultimaTentativa = posicao;
   }
 
+  for (let x = LIMITES.minX; x <= LIMITES.maxX; x++) {
+    for (let y = LIMITES.minY; y <= LIMITES.maxY; y++) {
+      const chave = `${x}-${y}`;
+      if (!ocupadasSet.has(chave) && !obstaculosSet.has(chave)) {
+        return [x, y];
+      }
+    }
+  }
+
   return ultimaTentativa;
+};
+
+const expandirCorredor = (corredor, largura = 1) => {
+  const faixa = new Set();
+
+  corredor.forEach(([x, y]) => {
+    for (let dx = -largura; dx <= largura; dx++) {
+      for (let dy = -largura; dy <= largura; dy++) {
+        const nx = x + dx;
+        const ny = y + dy;
+
+        if (
+          nx >= LIMITES.minX &&
+          nx <= LIMITES.maxX &&
+          ny >= LIMITES.minY &&
+          ny <= LIMITES.maxY
+        ) {
+          faixa.add(`${nx}-${ny}`);
+        }
+      }
+    }
+  });
+
+  return faixa;
+};
+
+const criarCorredor = (inicio, fim) => {
+  const corredor = [];
+  if (!inicio || !fim) {
+    return corredor;
+  }
+
+  let [xAtual, yAtual] = inicio;
+  const [xDestino, yDestino] = fim;
+
+  while (xAtual !== xDestino) {
+    corredor.push([xAtual, yAtual]);
+    xAtual += Math.sign(xDestino - xAtual);
+  }
+
+  while (yAtual !== yDestino) {
+    corredor.push([xAtual, yAtual]);
+    yAtual += Math.sign(yDestino - yAtual);
+  }
+
+  corredor.push([xDestino, yDestino]);
+  return corredor;
+};
+
+const removerObstaculosEmFaixas = (obstaculos, faixas) => {
+  if (!faixas.length) {
+    return obstaculos;
+  }
+
+  const faixaSet = new Set();
+  faixas.forEach((faixa) => {
+    faixa.forEach((chave) => faixaSet.add(chave));
+  });
+
+  return obstaculos.filter(([x, y]) => !faixaSet.has(`${x}-${y}`));
+};
+
+const lapidarObstaculosParaFluxo = (obstaculos, jogador, objetivo) => {
+  if (!jogador || jogador.length !== 2) {
+    return obstaculos;
+  }
+
+  const faixas = [expandirCorredor([jogador], 2)];
+
+  if (objetivo && objetivo.length === 2) {
+    faixas.push(expandirCorredor(criarCorredor(jogador, objetivo), 1));
+    faixas.push(expandirCorredor(criarCorredor(objetivo, CASTLE_TILES[0]), 2));
+  }
+
+  return removerObstaculosEmFaixas(obstaculos, faixas);
 };
 
 export default function RepGame() {
@@ -76,8 +161,14 @@ export default function RepGame() {
       obstaculosIniciais
     );
 
+    const obstaculosLapidados = lapidarObstaculosParaFluxo(
+      obstaculosIniciais,
+      jogadorInicial,
+      objetivoInicial
+    );
+
     setupRef.current = {
-      obstaculos: obstaculosIniciais,
+      obstaculos: obstaculosLapidados,
       terrenos: terrenosIniciais,
       objetivo: objetivoInicial,
       jogador: jogadorInicial,
@@ -274,7 +365,13 @@ export default function RepGame() {
     const novoObjetivo = gerarPosicaoLivre([], novosObstaculos);
     const novoJogador = gerarPosicaoLivre([novoObjetivo], novosObstaculos);
 
-    setObst(novosObstaculos);
+    const obstaculosLapidados = lapidarObstaculosParaFluxo(
+      novosObstaculos,
+      novoJogador,
+      novoObjetivo
+    );
+
+    setObst(obstaculosLapidados);
     setLamaCapim(novoTerreno);
     setObjetivo(novoObjetivo);
     setPlayer(novoJogador);

--- a/app/jogo/RepGame.jsx
+++ b/app/jogo/RepGame.jsx
@@ -13,6 +13,10 @@ const CASTLE_TILES = [
   [3, 24],
   [3, 25],
 ];
+const coordKey = (x, y) => `${x}-${y}`;
+const CASTLE_TILE_KEYS = new Set(
+  CASTLE_TILES.map(([x, y]) => coordKey(x, y))
+);
 const MAX_DISTANCE = Math.hypot(
   LIMITES.maxX - LIMITES.minX,
   LIMITES.maxY - LIMITES.minY
@@ -41,8 +45,8 @@ const gerarTerrenos = () =>
 const PARTICLES = Array.from({ length: 12 }, (_, index) => index);
 
 const gerarPosicaoLivre = (ocupadas = [], obstaculos = []) => {
-  const ocupadasSet = new Set(ocupadas.map(([x, y]) => `${x}-${y}`));
-  const obstaculosSet = new Set(obstaculos.map(([x, y]) => `${x}-${y}`));
+  const ocupadasSet = new Set(ocupadas.map(([x, y]) => coordKey(x, y)));
+  const obstaculosSet = new Set(obstaculos.map(([x, y]) => coordKey(x, y)));
   let ultimaTentativa = [LIMITES.minX, LIMITES.minY];
 
   for (let tentativas = 0; tentativas < 500; tentativas++) {
@@ -50,10 +54,8 @@ const gerarPosicaoLivre = (ocupadas = [], obstaculos = []) => {
       numeroAleatorio(15, 47),
       numeroAleatorio(12, 47),
     ];
-    const chave = `${posicao[0]}-${posicao[1]}`;
-    const tileCastelo = CASTLE_TILES.some(
-      ([x, y]) => x === posicao[0] && y === posicao[1]
-    );
+    const chave = coordKey(posicao[0], posicao[1]);
+    const tileCastelo = CASTLE_TILE_KEYS.has(chave);
 
     if (!ocupadasSet.has(chave) && !obstaculosSet.has(chave) && !tileCastelo) {
       return posicao;
@@ -64,7 +66,7 @@ const gerarPosicaoLivre = (ocupadas = [], obstaculos = []) => {
 
   for (let x = LIMITES.minX; x <= LIMITES.maxX; x++) {
     for (let y = LIMITES.minY; y <= LIMITES.maxY; y++) {
-      const chave = `${x}-${y}`;
+      const chave = coordKey(x, y);
       if (!ocupadasSet.has(chave) && !obstaculosSet.has(chave)) {
         return [x, y];
       }
@@ -188,6 +190,11 @@ export default function RepGame() {
   );
   const [warningMessage, setWarningMessage] = useState("");
 
+  const obstaculosKeySet = useMemo(
+    () => new Set(obst.map(([x, y]) => coordKey(x, y))),
+    [obst]
+  );
+
   const distanciaObjetivo = useMemo(() => {
     if (
       objetivoEncontrado ||
@@ -285,6 +292,10 @@ export default function RepGame() {
           posicaoAtual[0] + delta[0],
           posicaoAtual[1] + delta[1],
         ];
+        const proximaChave = coordKey(
+          proximaPosicao[0],
+          proximaPosicao[1]
+        );
 
         const foraDoMapa =
           proximaPosicao[0] < LIMITES.minX ||
@@ -297,18 +308,14 @@ export default function RepGame() {
           return posicaoAtual;
         }
 
-        const temObstaculo = obst.some(
-          ([x, y]) => x === proximaPosicao[0] && y === proximaPosicao[1]
-        );
+        const temObstaculo = obstaculosKeySet.has(proximaChave);
 
         if (temObstaculo) {
           setWarningMessage("Algo bloqueia o caminho!");
           return posicaoAtual;
         }
 
-        const tileCastelo = CASTLE_TILES.some(
-          ([x, y]) => x === proximaPosicao[0] && y === proximaPosicao[1]
-        );
+        const tileCastelo = CASTLE_TILE_KEYS.has(proximaChave);
 
         if (!objetivoEncontrado && tileCastelo) {
           setWarningMessage(
@@ -349,7 +356,13 @@ export default function RepGame() {
         return proximaPosicao;
       });
     },
-    [tela, personagemCastelo, obst, objetivo, objetivoEncontrado]
+    [
+      tela,
+      personagemCastelo,
+      obstaculosKeySet,
+      objetivo,
+      objetivoEncontrado,
+    ]
   );
 
   useEffect(() => {
@@ -380,6 +393,12 @@ export default function RepGame() {
     setMover(0);
     setStatusMessage("Use as setas para explorar e encontrar a Excalibur!");
     setWarningMessage("");
+    setupRef.current = {
+      obstaculos: obstaculosLapidados,
+      terrenos: novoTerreno,
+      objetivo: novoObjetivo,
+      jogador: novoJogador,
+    };
   }, []);
 
   const iniciarAventura = useCallback(() => {

--- a/app/jogo/RepGame.jsx
+++ b/app/jogo/RepGame.jsx
@@ -3,7 +3,6 @@
 import { useState, useEffect, useMemo, useCallback, useRef } from "react";
 import "./Styles/StyleRepGame.css";
 import Tabuleiro from "./Tabuleiro";
-import TelaInicial from "./TelaInicial";
 
 const LIMITES = { minX: 3, maxX: 47, minY: 10, maxY: 47 };
 const OBSTACLE_COUNT = 160;
@@ -23,10 +22,6 @@ const MOVIMENTOS = {
   ArrowLeft: [0, -1],
   ArrowRight: [0, 1],
 };
-const MAX_DISTANCE = Math.hypot(
-  LIMITES.maxX - LIMITES.minX,
-  LIMITES.maxY - LIMITES.minY
-);
 
 const numeroAleatorio = (min, max) => {
   const inteiroMin = Math.ceil(min);
@@ -47,9 +42,6 @@ const gerarTerrenos = () =>
     numeroAleatorio(10, 47),
     numeroAleatorio(1, 2),
   ]);
-
-const PARTICLES = Array.from({ length: 12 }, (_, index) => index);
-const TIP_SIZES = ["compact", "medium", "expanded"];
 
 const gerarPosicaoLivre = (ocupadas = [], obstaculos = []) => {
   const ocupadasSet = new Set(ocupadas.map(([x, y]) => coordKey(x, y)));
@@ -192,92 +184,13 @@ export default function RepGame() {
   const [lamaCapim, setLamaCapim] = useState(setupRef.current.terrenos);
   const [player, setPlayer] = useState(setupRef.current.jogador);
   const [objetivo, setObjetivo] = useState(setupRef.current.objetivo);
-  const [mover, setMover] = useState(0);
   const [objetivoEncontrado, setObjetivoEncontrado] = useState(false);
-  const [tela, setTela] = useState(true);
   const [personagemCastelo, setPersonagemCastelo] = useState(true);
-  const [statusMessage, setStatusMessage] = useState(
-    "Use as setas do teclado para explorar a floresta."
-  );
-  const [warningMessage, setWarningMessage] = useState("");
-  const [tipsVisible, setTipsVisible] = useState(true);
-  const [tipsSizeIndex, setTipsSizeIndex] = useState(1);
 
   const obstaculosKeySet = useMemo(
     () => new Set(obst.map(([x, y]) => coordKey(x, y))),
     [obst]
   );
-
-  const distanciaObjetivo = useMemo(() => {
-    if (
-      objetivoEncontrado ||
-      objetivo[0] == null ||
-      objetivo[1] == null ||
-      player[0] == null ||
-      player[1] == null
-    ) {
-      return 0;
-    }
-
-    return Math.hypot(player[0] - objetivo[0], player[1] - objetivo[1]);
-  }, [objetivoEncontrado, objetivo, player]);
-
-  const progressoObjetivo = useMemo(() => {
-    if (objetivoEncontrado) {
-      return 100;
-    }
-
-    const progresso =
-      ((MAX_DISTANCE - Math.min(distanciaObjetivo, MAX_DISTANCE)) /
-        MAX_DISTANCE) *
-      100;
-
-    return Math.max(0, Math.min(100, Math.round(progresso)));
-  }, [distanciaObjetivo, objetivoEncontrado]);
-
-  const progressoDescricao = useMemo(() => {
-    if (objetivoEncontrado) {
-      return "Corra para o castelo!";
-    }
-    if (progressoObjetivo > 80) {
-      return "Você sente a Excalibur muito perto.";
-    }
-    if (progressoObjetivo > 55) {
-      return "Pegadas frescas indicam que o objetivo está próximo.";
-    }
-    if (progressoObjetivo > 30) {
-      return "Continue avançando, o brilho começa a aparecer.";
-    }
-    return "O castelo está distante, explore com calma.";
-  }, [objetivoEncontrado, progressoObjetivo]);
-
-  const statusHighlightClass = useMemo(() => {
-    if (objetivoEncontrado) {
-      return "floating-panel__message--success";
-    }
-    if (progressoObjetivo >= 70) {
-      return "floating-panel__message--near";
-    }
-    if (progressoObjetivo <= 25) {
-      return "floating-panel__message--calm";
-    }
-    return "";
-  }, [objetivoEncontrado, progressoObjetivo]);
-
-  useEffect(() => {
-    if (!warningMessage) {
-      return;
-    }
-
-    const timeout = setTimeout(() => setWarningMessage(""), 1800);
-    return () => clearTimeout(timeout);
-  }, [warningMessage]);
-
-  useEffect(() => {
-    if (!tela && objetivoEncontrado) {
-      setStatusMessage("Você encontrou a Excalibur! Retorne ao castelo.");
-    }
-  }, [objetivoEncontrado, tela]);
 
   const avaliarMovimento = useCallback(
     (posicaoAtual, delta) => {
@@ -296,28 +209,17 @@ export default function RepGame() {
         proximaPosicao[1] < LIMITES.minY ||
         proximaPosicao[1] > LIMITES.maxY
       ) {
-        return {
-          proximaPosicao: posicaoAtual,
-          warning: "As árvores fecham o caminho por aqui.",
-        };
+        return null;
       }
 
       if (obstaculosKeySet.has(proximaChave)) {
-        return {
-          proximaPosicao: posicaoAtual,
-          warning: "Algo bloqueia o caminho!",
-        };
+        return null;
       }
 
       const tileCastelo = CASTLE_TILE_KEYS.has(proximaChave);
 
       if (!objetivoEncontrado && tileCastelo) {
-        return {
-          proximaPosicao: posicaoAtual,
-          warning: "Encontre a Excalibur antes de entrar no castelo!",
-          status:
-            "Continue explorando a floresta para achar a espada lendária.",
-        };
+        return null;
       }
 
       const encontrouObjetivo =
@@ -335,9 +237,25 @@ export default function RepGame() {
     [objetivoEncontrado, objetivo, obstaculosKeySet]
   );
 
+  const reiniciarJogo = useCallback(() => {
+    const novoCenario = criarNovoCenario();
+
+    setObst(novoCenario.obstaculos);
+    setLamaCapim(novoCenario.terrenos);
+    setObjetivo(novoCenario.objetivo);
+    setPlayer(novoCenario.jogador);
+    setObjetivoEncontrado(false);
+    setPersonagemCastelo(true);
+    setupRef.current = novoCenario;
+  }, []);
+
   const handleKeyDown = useCallback(
     (event) => {
-      if (tela || !personagemCastelo) {
+      if (!personagemCastelo) {
+        if (event.key === "Enter" || event.key === " ") {
+          event.preventDefault();
+          reiniciarJogo();
+        }
         return;
       }
 
@@ -352,32 +270,23 @@ export default function RepGame() {
       setPlayer((posicaoAtual) => {
         const resultado = avaliarMovimento(posicaoAtual, delta);
 
-        if (resultado.warning) {
-          setWarningMessage(resultado.warning);
-          if (resultado.status) {
-            setStatusMessage(resultado.status);
-          }
+        if (!resultado) {
           return posicaoAtual;
         }
-
-        setWarningMessage("");
-        setMover((prev) => prev + 1);
 
         if (resultado.encontrouObjetivo) {
           setObjetivoEncontrado(true);
           setObjetivo([null, null]);
-          setStatusMessage("Você encontrou a Excalibur! Retorne ao castelo.");
         }
 
         if (resultado.entrouNoCastelo) {
           setPersonagemCastelo(false);
-          setStatusMessage("Missão cumprida! Stuart chegou ao castelo.");
         }
 
         return resultado.proximaPosicao ?? posicaoAtual;
       });
     },
-    [tela, personagemCastelo, avaliarMovimento]
+    [avaliarMovimento, personagemCastelo, reiniciarJogo]
   );
 
   useEffect(() => {
@@ -387,157 +296,30 @@ export default function RepGame() {
     };
   }, [handleKeyDown]);
 
-  const reiniciarJogo = useCallback(() => {
-    const novoCenario = criarNovoCenario();
-
-    setObst(novoCenario.obstaculos);
-    setLamaCapim(novoCenario.terrenos);
-    setObjetivo(novoCenario.objetivo);
-    setPlayer(novoCenario.jogador);
-    setPersonagemCastelo(true);
-    setObjetivoEncontrado(false);
-    setMover(0);
-    setStatusMessage("Use as setas do teclado para explorar a floresta.");
-    setWarningMessage("");
-    setupRef.current = novoCenario;
-  }, []);
-
-  const iniciarAventura = useCallback(() => {
-    reiniciarJogo();
-    setTela(false);
-  }, [reiniciarJogo]);
-
-  const toggleTipsVisibility = useCallback(() => {
-    setTipsVisible((prev) => !prev);
-  }, []);
-
-  const cycleTipsSize = useCallback(() => {
-    setTipsSizeIndex((prev) => (prev + 1) % TIP_SIZES.length);
-  }, []);
-
-  const tipsSize = TIP_SIZES[tipsSizeIndex];
-
   return (
     <div className="game">
-      <div className="game__layer" aria-hidden="true">
-        <div className="game__aurora" />
-        <div className="game__particles">
-          {PARTICLES.map((particle) => (
-            <span
-              key={particle}
-              className={`game__particle game__particle--${(particle % 6) + 1}`}
-            />
-          ))}
-        </div>
+      <div className="game__stage">
+        <Tabuleiro
+          jogador={player}
+          obj={objetivo}
+          obst={obst}
+          reiniciarJogo={reiniciarJogo}
+          LamaCapim={lamaCapim}
+        />
       </div>
-      {!tela && (
-        <>
-          <div className="hud" role="status">
-            <div className="hud__stat">
-              <span className="hud__label">Movimentos</span>
-              <span className="hud__value">{mover}</span>
-            </div>
-            <div className="hud__stat">
-              <span className="hud__label">Objetivo</span>
-              <span
-                className={`hud__value ${
-                  objetivoEncontrado ? "hud__value--success" : ""
-                }`}
-              >
-                {objetivoEncontrado ? "Encontrado" : "Perdido"}
-              </span>
-            </div>
-            <button className="hud__button" onClick={reiniciarJogo}>
-              Reiniciar aventura
-            </button>
-          </div>
 
-          <div className="game__stage">
-            <div className="board-wrapper">
-              <Tabuleiro
-                jogador={player}
-                obj={objetivo}
-                obst={obst}
-                reiniciarJogo={reiniciarJogo}
-                LamaCapim={lamaCapim}
-              />
-            </div>
-          </div>
-
-          {tipsVisible ? (
-            <aside
-              className={`floating-panel floating-panel--${tipsSize}`}
-              role="complementary"
-              aria-label="Diário de bordo e instruções"
-            >
-              <div className="floating-panel__header">
-                <h2 className="floating-panel__title">Diário de bordo</h2>
-                <div className="floating-panel__actions">
-                  <button
-                    type="button"
-                    className="floating-panel__action"
-                    onClick={cycleTipsSize}
-                  >
-                    Ajustar tamanho
-                  </button>
-                  <button
-                    type="button"
-                    className="floating-panel__action"
-                    onClick={toggleTipsVisibility}
-                    aria-label="Ocultar instruções"
-                  >
-                    Ocultar
-                  </button>
-                </div>
-              </div>
-              <p className={`floating-panel__message ${statusHighlightClass}`}>
-                {statusMessage}
-              </p>
-              {warningMessage && (
-                <p className="floating-panel__warning" aria-live="assertive">
-                  {warningMessage}
-                </p>
-              )}
-              <div className="floating-panel__progress" role="presentation">
-                <span className="floating-panel__label">
-                  Distância até o objetivo
-                </span>
-                <div className="floating-panel__track" aria-hidden="true">
-                  <div
-                    className="floating-panel__fill"
-                    style={{ width: `${progressoObjetivo}%` }}
-                  />
-                </div>
-                <span className="floating-panel__hint">{progressoDescricao}</span>
-              </div>
-              <ul className="floating-panel__tips">
-                <li>Use as teclas direcionais para mover Stuart.</li>
-                <li>Evite rios, lama e pedras para não recomeçar.</li>
-                <li>Leve a Excalibur até o castelo para vencer.</li>
-              </ul>
-            </aside>
-          ) : (
+      {!personagemCastelo && (
+        <div className="game__overlay" role="dialog" aria-live="assertive">
+          <div className="game__overlay-card">
+            <h1 className="game__overlay-title">Missão cumprida!</h1>
+            <p className="game__overlay-text">
+              Pressione Enter ou clique para jogar novamente.
+            </p>
             <button
               type="button"
-              className="floating-panel__toggle"
-              onClick={toggleTipsVisibility}
+              className="game__overlay-button"
+              onClick={reiniciarJogo}
             >
-              Mostrar instruções
-            </button>
-          )}
-        </>
-      )}
-
-      {tela && <TelaInicial iniciarJogo={iniciarAventura} />}
-
-      {!tela && !personagemCastelo && (
-        <div className="final" role="dialog" aria-live="assertive">
-          <div className="final__content">
-            <h1 className="final__title">Parabéns! Você chegou ao castelo.</h1>
-            <p className="final__subtitle">
-              Stuart está salvo graças ao seu caminho certeiro.
-            </p>
-            <button className="final__button" onClick={reiniciarJogo}>
               Jogar novamente
             </button>
           </div>

--- a/app/jogo/RepGame.jsx
+++ b/app/jogo/RepGame.jsx
@@ -37,6 +37,8 @@ const gerarTerrenos = () =>
     numeroAleatorio(1, 2),
   ]);
 
+const PARTICLES = Array.from({ length: 12 }, (_, index) => index);
+
 const gerarPosicaoLivre = (ocupadas = [], obstaculos = []) => {
   const ocupadasSet = new Set(ocupadas.map(([x, y]) => `${x}-${y}`));
   const obstaculosSet = new Set(obstaculos.map(([x, y]) => `${x}-${y}`));
@@ -136,6 +138,19 @@ export default function RepGame() {
       return "Continue avançando, o brilho começa a aparecer.";
     }
     return "O castelo está distante, explore com calma.";
+  }, [objetivoEncontrado, progressoObjetivo]);
+
+  const statusHighlightClass = useMemo(() => {
+    if (objetivoEncontrado) {
+      return "status-panel__message--success";
+    }
+    if (progressoObjetivo >= 70) {
+      return "status-panel__message--near";
+    }
+    if (progressoObjetivo <= 25) {
+      return "status-panel__message--calm";
+    }
+    return "";
   }, [objetivoEncontrado, progressoObjetivo]);
 
   useEffect(() => {
@@ -277,6 +292,17 @@ export default function RepGame() {
 
   return (
     <div className="game">
+      <div className="game__layer" aria-hidden="true">
+        <div className="game__aurora" />
+        <div className="game__particles">
+          {PARTICLES.map((particle) => (
+            <span
+              key={particle}
+              className={`game__particle game__particle--${(particle % 6) + 1}`}
+            />
+          ))}
+        </div>
+      </div>
       {!tela && (
         <>
           <div className="hud" role="status">
@@ -312,9 +338,13 @@ export default function RepGame() {
 
             <aside className="status-panel">
               <h2 className="status-panel__title">Diário de bordo</h2>
-              <p className="status-panel__message">{statusMessage}</p>
+              <p className={`status-panel__message ${statusHighlightClass}`}>
+                {statusMessage}
+              </p>
               {warningMessage && (
-                <p className="status-panel__warning">{warningMessage}</p>
+                <p className="status-panel__warning" aria-live="assertive">
+                  {warningMessage}
+                </p>
               )}
               <div className="progress" role="presentation">
                 <span className="progress__label">Distância até o objetivo</span>

--- a/app/jogo/RepGame.jsx
+++ b/app/jogo/RepGame.jsx
@@ -49,6 +49,7 @@ const gerarTerrenos = () =>
   ]);
 
 const PARTICLES = Array.from({ length: 12 }, (_, index) => index);
+const TIP_SIZES = ["compact", "medium", "expanded"];
 
 const gerarPosicaoLivre = (ocupadas = [], obstaculos = []) => {
   const ocupadasSet = new Set(ocupadas.map(([x, y]) => coordKey(x, y)));
@@ -199,6 +200,8 @@ export default function RepGame() {
     "Use as setas do teclado para explorar a floresta."
   );
   const [warningMessage, setWarningMessage] = useState("");
+  const [tipsVisible, setTipsVisible] = useState(true);
+  const [tipsSizeIndex, setTipsSizeIndex] = useState(1);
 
   const obstaculosKeySet = useMemo(
     () => new Set(obst.map(([x, y]) => coordKey(x, y))),
@@ -250,13 +253,13 @@ export default function RepGame() {
 
   const statusHighlightClass = useMemo(() => {
     if (objetivoEncontrado) {
-      return "status-panel__message--success";
+      return "floating-panel__message--success";
     }
     if (progressoObjetivo >= 70) {
-      return "status-panel__message--near";
+      return "floating-panel__message--near";
     }
     if (progressoObjetivo <= 25) {
-      return "status-panel__message--calm";
+      return "floating-panel__message--calm";
     }
     return "";
   }, [objetivoEncontrado, progressoObjetivo]);
@@ -404,6 +407,16 @@ export default function RepGame() {
     setTela(false);
   }, [reiniciarJogo]);
 
+  const toggleTipsVisibility = useCallback(() => {
+    setTipsVisible((prev) => !prev);
+  }, []);
+
+  const cycleTipsSize = useCallback(() => {
+    setTipsSizeIndex((prev) => (prev + 1) % TIP_SIZES.length);
+  }, []);
+
+  const tipsSize = TIP_SIZES[tipsSizeIndex];
+
   return (
     <div className="game">
       <div className="game__layer" aria-hidden="true">
@@ -439,7 +452,7 @@ export default function RepGame() {
             </button>
           </div>
 
-          <div className="game__content">
+          <div className="game__stage">
             <div className="board-wrapper">
               <Tabuleiro
                 jogador={player}
@@ -449,34 +462,69 @@ export default function RepGame() {
                 LamaCapim={lamaCapim}
               />
             </div>
+          </div>
 
-            <aside className="status-panel">
-              <h2 className="status-panel__title">Diário de bordo</h2>
-              <p className={`status-panel__message ${statusHighlightClass}`}>
+          {tipsVisible ? (
+            <aside
+              className={`floating-panel floating-panel--${tipsSize}`}
+              role="complementary"
+              aria-label="Diário de bordo e instruções"
+            >
+              <div className="floating-panel__header">
+                <h2 className="floating-panel__title">Diário de bordo</h2>
+                <div className="floating-panel__actions">
+                  <button
+                    type="button"
+                    className="floating-panel__action"
+                    onClick={cycleTipsSize}
+                  >
+                    Ajustar tamanho
+                  </button>
+                  <button
+                    type="button"
+                    className="floating-panel__action"
+                    onClick={toggleTipsVisibility}
+                    aria-label="Ocultar instruções"
+                  >
+                    Ocultar
+                  </button>
+                </div>
+              </div>
+              <p className={`floating-panel__message ${statusHighlightClass}`}>
                 {statusMessage}
               </p>
               {warningMessage && (
-                <p className="status-panel__warning" aria-live="assertive">
+                <p className="floating-panel__warning" aria-live="assertive">
                   {warningMessage}
                 </p>
               )}
-              <div className="progress" role="presentation">
-                <span className="progress__label">Distância até o objetivo</span>
-                <div className="progress__track" aria-hidden="true">
+              <div className="floating-panel__progress" role="presentation">
+                <span className="floating-panel__label">
+                  Distância até o objetivo
+                </span>
+                <div className="floating-panel__track" aria-hidden="true">
                   <div
-                    className="progress__fill"
+                    className="floating-panel__fill"
                     style={{ width: `${progressoObjetivo}%` }}
                   />
                 </div>
-                <span className="progress__hint">{progressoDescricao}</span>
+                <span className="floating-panel__hint">{progressoDescricao}</span>
               </div>
-              <ul className="status-panel__tips">
+              <ul className="floating-panel__tips">
                 <li>Use as teclas direcionais para mover Stuart.</li>
                 <li>Evite rios, lama e pedras para não recomeçar.</li>
                 <li>Leve a Excalibur até o castelo para vencer.</li>
               </ul>
             </aside>
-          </div>
+          ) : (
+            <button
+              type="button"
+              className="floating-panel__toggle"
+              onClick={toggleTipsVisibility}
+            >
+              Mostrar instruções
+            </button>
+          )}
         </>
       )}
 

--- a/app/jogo/RepGame.jsx
+++ b/app/jogo/RepGame.jsx
@@ -17,6 +17,12 @@ const coordKey = (x, y) => `${x}-${y}`;
 const CASTLE_TILE_KEYS = new Set(
   CASTLE_TILES.map(([x, y]) => coordKey(x, y))
 );
+const MOVIMENTOS = {
+  ArrowUp: [-1, 0],
+  ArrowDown: [1, 0],
+  ArrowLeft: [0, -1],
+  ArrowRight: [0, 1],
+};
 const MAX_DISTANCE = Math.hypot(
   LIMITES.maxX - LIMITES.minX,
   LIMITES.maxY - LIMITES.minY
@@ -151,30 +157,34 @@ const lapidarObstaculosParaFluxo = (obstaculos, jogador, objetivo) => {
   return removerObstaculosEmFaixas(obstaculos, faixas);
 };
 
+const criarNovoCenario = () => {
+  const obstaculosIniciais = gerarObstaculos();
+  const terrenosIniciais = gerarTerrenos();
+  const objetivoInicial = gerarPosicaoLivre([], obstaculosIniciais);
+  const jogadorInicial = gerarPosicaoLivre(
+    [objetivoInicial],
+    obstaculosIniciais
+  );
+
+  const obstaculosLapidados = lapidarObstaculosParaFluxo(
+    obstaculosIniciais,
+    jogadorInicial,
+    objetivoInicial
+  );
+
+  return {
+    obstaculos: obstaculosLapidados,
+    terrenos: terrenosIniciais,
+    objetivo: objetivoInicial,
+    jogador: jogadorInicial,
+  };
+};
+
 export default function RepGame() {
   const setupRef = useRef(null);
 
   if (!setupRef.current) {
-    const obstaculosIniciais = gerarObstaculos();
-    const terrenosIniciais = gerarTerrenos();
-    const objetivoInicial = gerarPosicaoLivre([], obstaculosIniciais);
-    const jogadorInicial = gerarPosicaoLivre(
-      [objetivoInicial],
-      obstaculosIniciais
-    );
-
-    const obstaculosLapidados = lapidarObstaculosParaFluxo(
-      obstaculosIniciais,
-      jogadorInicial,
-      objetivoInicial
-    );
-
-    setupRef.current = {
-      obstaculos: obstaculosLapidados,
-      terrenos: terrenosIniciais,
-      objetivo: objetivoInicial,
-      jogador: jogadorInicial,
-    };
+    setupRef.current = criarNovoCenario();
   }
 
   const [obst, setObst] = useState(setupRef.current.obstaculos);
@@ -266,20 +276,69 @@ export default function RepGame() {
     }
   }, [objetivoEncontrado, tela]);
 
+  const avaliarMovimento = useCallback(
+    (posicaoAtual, delta) => {
+      const proximaPosicao = [
+        posicaoAtual[0] + delta[0],
+        posicaoAtual[1] + delta[1],
+      ];
+      const proximaChave = coordKey(
+        proximaPosicao[0],
+        proximaPosicao[1]
+      );
+
+      if (
+        proximaPosicao[0] < LIMITES.minX ||
+        proximaPosicao[0] > LIMITES.maxX ||
+        proximaPosicao[1] < LIMITES.minY ||
+        proximaPosicao[1] > LIMITES.maxY
+      ) {
+        return {
+          proximaPosicao: posicaoAtual,
+          warning: "As árvores fecham o caminho por aqui.",
+        };
+      }
+
+      if (obstaculosKeySet.has(proximaChave)) {
+        return {
+          proximaPosicao: posicaoAtual,
+          warning: "Algo bloqueia o caminho!",
+        };
+      }
+
+      const tileCastelo = CASTLE_TILE_KEYS.has(proximaChave);
+
+      if (!objetivoEncontrado && tileCastelo) {
+        return {
+          proximaPosicao: posicaoAtual,
+          warning: "Encontre a Excalibur antes de entrar no castelo!",
+          status:
+            "Continue explorando a floresta para achar a espada lendária.",
+        };
+      }
+
+      const encontrouObjetivo =
+        objetivo[0] != null &&
+        objetivo[1] != null &&
+        proximaPosicao[0] === objetivo[0] &&
+        proximaPosicao[1] === objetivo[1];
+
+      return {
+        proximaPosicao,
+        encontrouObjetivo,
+        entrouNoCastelo: objetivoEncontrado && tileCastelo,
+      };
+    },
+    [objetivoEncontrado, objetivo, obstaculosKeySet]
+  );
+
   const handleKeyDown = useCallback(
     (event) => {
       if (tela || !personagemCastelo) {
         return;
       }
 
-      const movimentos = {
-        ArrowUp: [-1, 0],
-        ArrowDown: [1, 0],
-        ArrowLeft: [0, -1],
-        ArrowRight: [0, 1],
-      };
-
-      const delta = movimentos[event.key];
+      const delta = MOVIMENTOS[event.key];
 
       if (!delta) {
         return;
@@ -288,81 +347,34 @@ export default function RepGame() {
       event.preventDefault();
 
       setPlayer((posicaoAtual) => {
-        const proximaPosicao = [
-          posicaoAtual[0] + delta[0],
-          posicaoAtual[1] + delta[1],
-        ];
-        const proximaChave = coordKey(
-          proximaPosicao[0],
-          proximaPosicao[1]
-        );
+        const resultado = avaliarMovimento(posicaoAtual, delta);
 
-        const foraDoMapa =
-          proximaPosicao[0] < LIMITES.minX ||
-          proximaPosicao[0] > LIMITES.maxX ||
-          proximaPosicao[1] < LIMITES.minY ||
-          proximaPosicao[1] > LIMITES.maxY;
-
-        if (foraDoMapa) {
-          setWarningMessage("As árvores fecham o caminho por aqui.");
-          return posicaoAtual;
-        }
-
-        const temObstaculo = obstaculosKeySet.has(proximaChave);
-
-        if (temObstaculo) {
-          setWarningMessage("Algo bloqueia o caminho!");
-          return posicaoAtual;
-        }
-
-        const tileCastelo = CASTLE_TILE_KEYS.has(proximaChave);
-
-        if (!objetivoEncontrado && tileCastelo) {
-          setWarningMessage(
-            "Encontre a Excalibur antes de entrar no castelo!"
-          );
-          setStatusMessage(
-            "Continue explorando a floresta para achar a espada lendária."
-          );
-          return posicaoAtual;
-        }
-
-        if (
-          posicaoAtual[0] === proximaPosicao[0] &&
-          posicaoAtual[1] === proximaPosicao[1]
-        ) {
+        if (resultado.warning) {
+          setWarningMessage(resultado.warning);
+          if (resultado.status) {
+            setStatusMessage(resultado.status);
+          }
           return posicaoAtual;
         }
 
         setWarningMessage("");
         setMover((prev) => prev + 1);
 
-        if (
-          objetivo[0] != null &&
-          objetivo[1] != null &&
-          proximaPosicao[0] === objetivo[0] &&
-          proximaPosicao[1] === objetivo[1]
-        ) {
+        if (resultado.encontrouObjetivo) {
           setObjetivoEncontrado(true);
           setObjetivo([null, null]);
           setStatusMessage("Você encontrou a Excalibur! Retorne ao castelo.");
         }
 
-        if (objetivoEncontrado && tileCastelo) {
+        if (resultado.entrouNoCastelo) {
           setPersonagemCastelo(false);
           setStatusMessage("Missão cumprida! Stuart chegou ao castelo.");
         }
 
-        return proximaPosicao;
+        return resultado.proximaPosicao ?? posicaoAtual;
       });
     },
-    [
-      tela,
-      personagemCastelo,
-      obstaculosKeySet,
-      objetivo,
-      objetivoEncontrado,
-    ]
+    [tela, personagemCastelo, avaliarMovimento]
   );
 
   useEffect(() => {
@@ -373,32 +385,18 @@ export default function RepGame() {
   }, [handleKeyDown]);
 
   const reiniciarJogo = useCallback(() => {
-    const novosObstaculos = gerarObstaculos();
-    const novoTerreno = gerarTerrenos();
-    const novoObjetivo = gerarPosicaoLivre([], novosObstaculos);
-    const novoJogador = gerarPosicaoLivre([novoObjetivo], novosObstaculos);
+    const novoCenario = criarNovoCenario();
 
-    const obstaculosLapidados = lapidarObstaculosParaFluxo(
-      novosObstaculos,
-      novoJogador,
-      novoObjetivo
-    );
-
-    setObst(obstaculosLapidados);
-    setLamaCapim(novoTerreno);
-    setObjetivo(novoObjetivo);
-    setPlayer(novoJogador);
+    setObst(novoCenario.obstaculos);
+    setLamaCapim(novoCenario.terrenos);
+    setObjetivo(novoCenario.objetivo);
+    setPlayer(novoCenario.jogador);
     setPersonagemCastelo(true);
     setObjetivoEncontrado(false);
     setMover(0);
-    setStatusMessage("Use as setas para explorar e encontrar a Excalibur!");
+    setStatusMessage("Use as setas do teclado para explorar a floresta.");
     setWarningMessage("");
-    setupRef.current = {
-      obstaculos: obstaculosLapidados,
-      terrenos: novoTerreno,
-      objetivo: novoObjetivo,
-      jogador: novoJogador,
-    };
+    setupRef.current = novoCenario;
   }, []);
 
   const iniciarAventura = useCallback(() => {

--- a/app/jogo/RepGame.jsx
+++ b/app/jogo/RepGame.jsx
@@ -1,150 +1,356 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo, useCallback, useRef } from "react";
 import "./Styles/StyleRepGame.css";
 import Tabuleiro from "./Tabuleiro";
 import TelaInicial from "./TelaInicial";
 
-export default function RepGame() {
-  function numeroAleatorio(min, max) {
-    min = Math.ceil(min);
-    max = Math.floor(max);
-    return Math.floor(Math.random() * (max - min + 1)) + min;
-  }
+const LIMITES = { minX: 3, maxX: 47, minY: 10, maxY: 47 };
+const CASTLE_TILES = [
+  [4, 24],
+  [4, 25],
+  [3, 24],
+  [3, 25],
+];
+const MAX_DISTANCE = Math.hypot(
+  LIMITES.maxX - LIMITES.minX,
+  LIMITES.maxY - LIMITES.minY
+);
 
-  const [player, setPlayer] = useState([
-    numeroAleatorio(15,47),
-    numeroAleatorio(12, 47),
-  ]);
-  const [Objetivo, setObjetivo] = useState([
+const numeroAleatorio = (min, max) => {
+  const inteiroMin = Math.ceil(min);
+  const inteiroMax = Math.floor(max);
+  return Math.floor(Math.random() * (inteiroMax - inteiroMin + 1)) + inteiroMin;
+};
+
+const gerarObstaculos = () =>
+  Array.from({ length: 200 }, () => [
     numeroAleatorio(15, 47),
-    numeroAleatorio(15, 47),
+    numeroAleatorio(10, 47),
+    numeroAleatorio(1, 2),
   ]);
 
-  const [obst, setObst] = useState([]);
-  const [lamaCapim, setLamaCapim] = useState([]);
-  const [mover, setMover] = useState(0);
-  const [ObjetivoEncontrado, setObjetivoEncontrado] = useState(false);
-  const [tela, setTela] = useState(true);
-  const [personagemCastelo, setPersonagemCastelo] = useState(true);
+const gerarTerrenos = () =>
+  Array.from({ length: 50 }, () => [
+    numeroAleatorio(15, 47),
+    numeroAleatorio(10, 47),
+    numeroAleatorio(1, 2),
+  ]);
 
-  useEffect(() => {
-    const numObstaculos = 200;
-    const obst = Array.from({ length: numObstaculos }, () => [
-      numeroAleatorio(15, 47),
-      numeroAleatorio(10, 47),
-      numeroAleatorio(1, 2),
-    ]);
-    const posicoesLamaCapim = Array.from({ length: 50 }, () => [
-      numeroAleatorio(15, 47),
-      numeroAleatorio(10, 47),
-      numeroAleatorio(1, 2),
-    ]);
-    setObst(obst);
-    setLamaCapim(posicoesLamaCapim);
-  }, []);
+const gerarPosicaoLivre = (ocupadas = [], obstaculos = []) => {
+  const ocupadasSet = new Set(ocupadas.map(([x, y]) => `${x}-${y}`));
+  const obstaculosSet = new Set(obstaculos.map(([x, y]) => `${x}-${y}`));
+  let ultimaTentativa = [LIMITES.minX, LIMITES.minY];
 
-  const handleKeyDown = (e) => {
-    const obstaculo = obst.find(
-      (o) =>
-        (e.key === "ArrowUp" && o[0] === player[0] - 1 && o[1] === player[1]) ||
-        (e.key === "ArrowDown" &&
-          o[0] === player[0] + 1 &&
-          o[1] === player[1]) ||
-        (e.key === "ArrowLeft" &&
-          o[0] === player[0] &&
-          o[1] === player[1] - 1) ||
-        (e.key === "ArrowRight" && o[0] === player[0] && o[1] === player[1] + 1)
+  for (let tentativas = 0; tentativas < 500; tentativas++) {
+    const posicao = [
+      numeroAleatorio(15, 47),
+      numeroAleatorio(12, 47),
+    ];
+    const chave = `${posicao[0]}-${posicao[1]}`;
+    const tileCastelo = CASTLE_TILES.some(
+      ([x, y]) => x === posicao[0] && y === posicao[1]
     );
 
-    const positionsArray = [
-      player[0] === 10 &&
-        (player[1] === 23 ||
-          player[1] === 24 ||
-          player[1] === 25 ||
-          player[1] === 26),
-      player[0] === 9 &&
-        (player[1] === 23 ||
-          player[1] === 24 ||
-          player[1] === 25 ||
-          player[1] === 26),
-    ];
-    if (!ObjetivoEncontrado && positionsArray.includes(true)) {
-      window.confirm("Ache o objetivo primeiro! Encontre a Excalibur!");
-      setPlayer([numeroAleatorio(15,47),
-        numeroAleatorio(12, 47),]);
+    if (!ocupadasSet.has(chave) && !obstaculosSet.has(chave) && !tileCastelo) {
+      return posicao;
+    }
+
+    ultimaTentativa = posicao;
+  }
+
+  return ultimaTentativa;
+};
+
+export default function RepGame() {
+  const setupRef = useRef(null);
+
+  if (!setupRef.current) {
+    const obstaculosIniciais = gerarObstaculos();
+    const terrenosIniciais = gerarTerrenos();
+    const objetivoInicial = gerarPosicaoLivre([], obstaculosIniciais);
+    const jogadorInicial = gerarPosicaoLivre(
+      [objetivoInicial],
+      obstaculosIniciais
+    );
+
+    setupRef.current = {
+      obstaculos: obstaculosIniciais,
+      terrenos: terrenosIniciais,
+      objetivo: objetivoInicial,
+      jogador: jogadorInicial,
+    };
+  }
+
+  const [obst, setObst] = useState(setupRef.current.obstaculos);
+  const [lamaCapim, setLamaCapim] = useState(setupRef.current.terrenos);
+  const [player, setPlayer] = useState(setupRef.current.jogador);
+  const [objetivo, setObjetivo] = useState(setupRef.current.objetivo);
+  const [mover, setMover] = useState(0);
+  const [objetivoEncontrado, setObjetivoEncontrado] = useState(false);
+  const [tela, setTela] = useState(true);
+  const [personagemCastelo, setPersonagemCastelo] = useState(true);
+  const [statusMessage, setStatusMessage] = useState(
+    "Use as setas do teclado para explorar a floresta."
+  );
+  const [warningMessage, setWarningMessage] = useState("");
+
+  const distanciaObjetivo = useMemo(() => {
+    if (
+      objetivoEncontrado ||
+      objetivo[0] == null ||
+      objetivo[1] == null ||
+      player[0] == null ||
+      player[1] == null
+    ) {
+      return 0;
+    }
+
+    return Math.hypot(player[0] - objetivo[0], player[1] - objetivo[1]);
+  }, [objetivoEncontrado, objetivo, player]);
+
+  const progressoObjetivo = useMemo(() => {
+    if (objetivoEncontrado) {
+      return 100;
+    }
+
+    const progresso =
+      ((MAX_DISTANCE - Math.min(distanciaObjetivo, MAX_DISTANCE)) /
+        MAX_DISTANCE) *
+      100;
+
+    return Math.max(0, Math.min(100, Math.round(progresso)));
+  }, [distanciaObjetivo, objetivoEncontrado]);
+
+  const progressoDescricao = useMemo(() => {
+    if (objetivoEncontrado) {
+      return "Corra para o castelo!";
+    }
+    if (progressoObjetivo > 80) {
+      return "Você sente a Excalibur muito perto.";
+    }
+    if (progressoObjetivo > 55) {
+      return "Pegadas frescas indicam que o objetivo está próximo.";
+    }
+    if (progressoObjetivo > 30) {
+      return "Continue avançando, o brilho começa a aparecer.";
+    }
+    return "O castelo está distante, explore com calma.";
+  }, [objetivoEncontrado, progressoObjetivo]);
+
+  useEffect(() => {
+    if (!warningMessage) {
       return;
     }
 
-    if (!obstaculo) {
-      if (e.key === "ArrowUp" && player[0] > 3) {
-        setPlayer([player[0] - 1, player[1]]);
-      } else if (e.key === "ArrowDown" && player[0] < 47) {
-        setPlayer([player[0] + 1, player[1]]);
-      } else if (e.key === "ArrowLeft" && player[1] > 10) {
-        setPlayer([player[0], player[1] - 1]);
-      } else if (e.key === "ArrowRight" && player[1] < 47) {
-        setPlayer([player[0], player[1] + 1]);
+    const timeout = setTimeout(() => setWarningMessage(""), 1800);
+    return () => clearTimeout(timeout);
+  }, [warningMessage]);
+
+  useEffect(() => {
+    if (!tela && objetivoEncontrado) {
+      setStatusMessage("Você encontrou a Excalibur! Retorne ao castelo.");
+    }
+  }, [objetivoEncontrado, tela]);
+
+  const handleKeyDown = useCallback(
+    (event) => {
+      if (tela || !personagemCastelo) {
+        return;
       }
-      setMover(mover + 1);
-    }
 
-    if (player[0] === Objetivo[0] && player[1] === Objetivo[1]) {
-      setObjetivoEncontrado(true);
-      setObjetivo([null, null]);
-    }
+      const movimentos = {
+        ArrowUp: [-1, 0],
+        ArrowDown: [1, 0],
+        ArrowLeft: [0, -1],
+        ArrowRight: [0, 1],
+      };
 
-    const castelo = [4, 24];
-    const castelo1 = [4, 25];
+      const delta = movimentos[event.key];
 
-    if (player[0] === castelo[0] && player[1] === castelo[1]) {
-      setPersonagemCastelo(false);
-    }
-    if (player[0] === castelo1[0] && player[1] === castelo1[1]) {
-      setPersonagemCastelo(false);
-    }
-  };
+      if (!delta) {
+        return;
+      }
+
+      event.preventDefault();
+
+      setPlayer((posicaoAtual) => {
+        const proximaPosicao = [
+          posicaoAtual[0] + delta[0],
+          posicaoAtual[1] + delta[1],
+        ];
+
+        const foraDoMapa =
+          proximaPosicao[0] < LIMITES.minX ||
+          proximaPosicao[0] > LIMITES.maxX ||
+          proximaPosicao[1] < LIMITES.minY ||
+          proximaPosicao[1] > LIMITES.maxY;
+
+        if (foraDoMapa) {
+          setWarningMessage("As árvores fecham o caminho por aqui.");
+          return posicaoAtual;
+        }
+
+        const temObstaculo = obst.some(
+          ([x, y]) => x === proximaPosicao[0] && y === proximaPosicao[1]
+        );
+
+        if (temObstaculo) {
+          setWarningMessage("Algo bloqueia o caminho!");
+          return posicaoAtual;
+        }
+
+        const tileCastelo = CASTLE_TILES.some(
+          ([x, y]) => x === proximaPosicao[0] && y === proximaPosicao[1]
+        );
+
+        if (!objetivoEncontrado && tileCastelo) {
+          setWarningMessage(
+            "Encontre a Excalibur antes de entrar no castelo!"
+          );
+          setStatusMessage(
+            "Continue explorando a floresta para achar a espada lendária."
+          );
+          return posicaoAtual;
+        }
+
+        if (
+          posicaoAtual[0] === proximaPosicao[0] &&
+          posicaoAtual[1] === proximaPosicao[1]
+        ) {
+          return posicaoAtual;
+        }
+
+        setWarningMessage("");
+        setMover((prev) => prev + 1);
+
+        if (
+          objetivo[0] != null &&
+          objetivo[1] != null &&
+          proximaPosicao[0] === objetivo[0] &&
+          proximaPosicao[1] === objetivo[1]
+        ) {
+          setObjetivoEncontrado(true);
+          setObjetivo([null, null]);
+          setStatusMessage("Você encontrou a Excalibur! Retorne ao castelo.");
+        }
+
+        if (objetivoEncontrado && tileCastelo) {
+          setPersonagemCastelo(false);
+          setStatusMessage("Missão cumprida! Stuart chegou ao castelo.");
+        }
+
+        return proximaPosicao;
+      });
+    },
+    [tela, personagemCastelo, obst, objetivo, objetivoEncontrado]
+  );
 
   useEffect(() => {
     window.addEventListener("keydown", handleKeyDown);
     return () => {
       window.removeEventListener("keydown", handleKeyDown);
     };
-  }, [player, ObjetivoEncontrado, obst]);
+  }, [handleKeyDown]);
 
-  const reiniciarJogo = () => {
-    setPlayer([numeroAleatorio(15,47),
-    numeroAleatorio(12, 47)]);
-    setObjetivo([numeroAleatorio(15,47),
-      numeroAleatorio(12, 47),]);
+  const reiniciarJogo = useCallback(() => {
+    const novosObstaculos = gerarObstaculos();
+    const novoTerreno = gerarTerrenos();
+    const novoObjetivo = gerarPosicaoLivre([], novosObstaculos);
+    const novoJogador = gerarPosicaoLivre([novoObjetivo], novosObstaculos);
+
+    setObst(novosObstaculos);
+    setLamaCapim(novoTerreno);
+    setObjetivo(novoObjetivo);
+    setPlayer(novoJogador);
     setPersonagemCastelo(true);
     setObjetivoEncontrado(false);
     setMover(0);
-  };
+    setStatusMessage("Use as setas para explorar e encontrar a Excalibur!");
+    setWarningMessage("");
+  }, []);
+
+  const iniciarAventura = useCallback(() => {
+    reiniciarJogo();
+    setTela(false);
+  }, [reiniciarJogo]);
 
   return (
     <div className="game">
-      {!tela & !personagemCastelo && (
-        <div className="final">
-          <h1 className="textoFinal1">Parabéns você chegou ao castelo!</h1>
-          <button className="reiniciar" onClick={reiniciarJogo}>
-            Reiniciar!
-          </button>
-        </div>
-      )}
       {!tela && (
-        <div>
-          <p className="contagem">{mover}</p>
-          <Tabuleiro
-            jogador={player}
-            obj={Objetivo}
-            obst={obst}
-            reiniciarJogo={reiniciarJogo}
-            LamaCapim={lamaCapim}
-          />
+        <>
+          <div className="hud" role="status">
+            <div className="hud__stat">
+              <span className="hud__label">Movimentos</span>
+              <span className="hud__value">{mover}</span>
+            </div>
+            <div className="hud__stat">
+              <span className="hud__label">Objetivo</span>
+              <span
+                className={`hud__value ${
+                  objetivoEncontrado ? "hud__value--success" : ""
+                }`}
+              >
+                {objetivoEncontrado ? "Encontrado" : "Perdido"}
+              </span>
+            </div>
+            <button className="hud__button" onClick={reiniciarJogo}>
+              Reiniciar aventura
+            </button>
+          </div>
+
+          <div className="game__content">
+            <div className="board-wrapper">
+              <Tabuleiro
+                jogador={player}
+                obj={objetivo}
+                obst={obst}
+                reiniciarJogo={reiniciarJogo}
+                LamaCapim={lamaCapim}
+              />
+            </div>
+
+            <aside className="status-panel">
+              <h2 className="status-panel__title">Diário de bordo</h2>
+              <p className="status-panel__message">{statusMessage}</p>
+              {warningMessage && (
+                <p className="status-panel__warning">{warningMessage}</p>
+              )}
+              <div className="progress" role="presentation">
+                <span className="progress__label">Distância até o objetivo</span>
+                <div className="progress__track" aria-hidden="true">
+                  <div
+                    className="progress__fill"
+                    style={{ width: `${progressoObjetivo}%` }}
+                  />
+                </div>
+                <span className="progress__hint">{progressoDescricao}</span>
+              </div>
+              <ul className="status-panel__tips">
+                <li>Use as teclas direcionais para mover Stuart.</li>
+                <li>Evite rios, lama e pedras para não recomeçar.</li>
+                <li>Leve a Excalibur até o castelo para vencer.</li>
+              </ul>
+            </aside>
+          </div>
+        </>
+      )}
+
+      {tela && <TelaInicial iniciarJogo={iniciarAventura} />}
+
+      {!tela && !personagemCastelo && (
+        <div className="final" role="dialog" aria-live="assertive">
+          <div className="final__content">
+            <h1 className="final__title">Parabéns! Você chegou ao castelo.</h1>
+            <p className="final__subtitle">
+              Stuart está salvo graças ao seu caminho certeiro.
+            </p>
+            <button className="final__button" onClick={reiniciarJogo}>
+              Jogar novamente
+            </button>
+          </div>
         </div>
       )}
-      {tela && <TelaInicial iniciarJogo={() => setTela(false)} />}
     </div>
   );
 }

--- a/app/jogo/Styles/Style.css
+++ b/app/jogo/Styles/Style.css
@@ -1,11 +1,11 @@
 .Personagem {
   background-image: url(Imagens/perso.gif);
-  background-size: cover;
+  background-size: contain;
   background-repeat: no-repeat;
-  z-index: 1;
-  width: 50px;
-  height: 50px;
-  filter: drop-shadow(0 0 12px rgba(255, 255, 255, 0.35));
+  background-position: center bottom;
+  width: calc(var(--cell-size) * 0.85);
+  height: calc(var(--cell-size) * 0.85);
+  filter: drop-shadow(0 0 14px rgba(255, 255, 255, 0.35));
   animation: heroPulse 1.6s ease-in-out infinite alternate;
 }
 
@@ -13,10 +13,10 @@
   background-image: url(Imagens/objetivo.png);
   background-size: contain;
   background-repeat: no-repeat;
-  z-index: 1;
-  width: 50px;
-  height: 70px;
-  filter: drop-shadow(0 25px 25px rgb(0 0 0 / 0.15));
+  background-position: center bottom;
+  width: calc(var(--cell-size) * 0.72);
+  height: calc(var(--cell-size) * 1.08);
+  filter: drop-shadow(0 20px 24px rgb(0 0 0 / 0.18));
   animation: bounce 1.1s ease-in-out infinite;
 }
 
@@ -25,7 +25,7 @@
     transform: translateY(0);
   }
   to {
-    transform: translateY(-2px) scale(1.03);
+    transform: translateY(-2px) scale(1.04);
   }
 }
 

--- a/app/jogo/Styles/Style.css
+++ b/app/jogo/Styles/Style.css
@@ -5,6 +5,8 @@
   z-index: 1;
   width: 50px;
   height: 50px;
+  filter: drop-shadow(0 0 12px rgba(255, 255, 255, 0.35));
+  animation: heroPulse 1.6s ease-in-out infinite alternate;
 }
 
 .objetivo {
@@ -15,5 +17,24 @@
   width: 50px;
   height: 70px;
   filter: drop-shadow(0 25px 25px rgb(0 0 0 / 0.15));
-  animation: bounce 1s infinite;
+  animation: bounce 1.1s ease-in-out infinite;
+}
+
+@keyframes heroPulse {
+  from {
+    transform: translateY(0);
+  }
+  to {
+    transform: translateY(-2px) scale(1.03);
+  }
+}
+
+@keyframes bounce {
+  0%,
+  100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-6px);
+  }
 }

--- a/app/jogo/Styles/StyleCelula.css
+++ b/app/jogo/Styles/StyleCelula.css
@@ -1,7 +1,7 @@
 .Celula {
   position: relative;
-  height: 50px;
-  width: 43px;
+  height: 58px;
+  width: 50px;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/app/jogo/Styles/StyleCelula.css
+++ b/app/jogo/Styles/StyleCelula.css
@@ -1,11 +1,12 @@
 .Celula {
   position: relative;
-  height: 58px;
-  width: 50px;
+  width: var(--cell-size);
+  height: var(--cell-height);
   display: flex;
   align-items: center;
   justify-content: center;
   transition: transform 0.2s ease, filter 0.2s ease;
+  flex-shrink: 0;
 }
 
 .Celula:hover,
@@ -17,112 +18,126 @@
 .Celula > * {
   position: absolute;
   z-index: 1;
+  pointer-events: none;
 }
 
 .Celula > .caminho {
   z-index: 0;
 }
+
 .arvore {
   background-image: url(Imagens/arvorenatal.png);
   background-size: contain;
   background-repeat: no-repeat;
-  width: 50px;
-  height: 80px;
+  width: var(--cell-size);
+  height: calc(var(--cell-size) * 1.6);
 }
+
 .arvore2 {
   background-image: url(Imagens/arvorenormal.png);
   background-size: contain;
   background-repeat: no-repeat;
-  width: 200px;
-  height: 100px;
+  width: calc(var(--cell-size) * 4);
+  height: calc(var(--cell-size) * 2);
 }
+
 .capim {
   background-image: url(Imagens/capim.png);
   background-size: contain;
   background-repeat: no-repeat;
   z-index: 2;
-  width: 50px;
-  height: 70px;
+  width: var(--cell-size);
+  height: calc(var(--cell-size) * 1.4);
 }
+
 .pedra {
   border-radius: 20%;
   background-image: url(Imagens/pedra.png);
   background-size: cover;
-  width: 70px;
-  height: 70px;
+  width: calc(var(--cell-size) * 1.4);
+  height: calc(var(--cell-size) * 1.4);
 }
+
 .lama {
   border-radius: 25%;
   background-image: url(Imagens/lama.png);
   background-size: contain;
   background-repeat: no-repeat;
   z-index: 0;
-  width: 50px;
-  height: 70px;
+  width: var(--cell-size);
+  height: calc(var(--cell-size) * 1.4);
 }
+
 .rio {
   border-radius: 0% 0% 10% 0%;
   background-image: url(Imagens/agua.png);
   background-size: contain;
   background-repeat: no-repeat;
   z-index: 1;
-  width: 50px;
-  height: 70px;
+  width: var(--cell-size);
+  height: calc(var(--cell-size) * 1.4);
 }
+
 .castelo1 {
   background-image: url(Imagens/castelo1.png);
   background-size: contain;
   background-repeat: no-repeat;
-  top: 4px;
-  width: 50px;
-  height: 70px;
+  top: calc(var(--cell-size) * 0.08);
+  width: var(--cell-size);
+  height: calc(var(--cell-size) * 1.4);
 }
+
 .castelo2 {
   background-image: url(Imagens/castelo2.png);
   background-size: contain;
   background-repeat: no-repeat;
-  right: -10px;
-  width: 50px;
-  height: 70px;
+  right: calc(var(--cell-size) * -0.2);
+  width: var(--cell-size);
+  height: calc(var(--cell-size) * 1.4);
 }
+
 .castelo3 {
   background-image: url(Imagens/castelo3.png);
   background-size: contain;
   background-repeat: no-repeat;
-  top: 4px;
-  width: 50px;
-  height: 70px;
+  top: calc(var(--cell-size) * 0.08);
+  width: var(--cell-size);
+  height: calc(var(--cell-size) * 1.4);
 }
+
 .castelo4 {
   background-image: url(Imagens/castelo4.png);
   background-size: contain;
   background-repeat: no-repeat;
-  right: -8px;
-  width: 50px;
-  height: 100px;
+  right: calc(var(--cell-size) * -0.16);
+  width: var(--cell-size);
+  height: calc(var(--cell-size) * 2);
 }
+
 .ponte1 {
   background-image: url(Imagens/ponte1.png);
   background-size: contain;
   background-repeat: no-repeat;
-  width: 50px;
-  height: 70px;
+  width: var(--cell-size);
+  height: calc(var(--cell-size) * 1.4);
   z-index: 0;
 }
+
 .ponte3 {
   background-image: url(Imagens/ponte2.png);
   background-size: contain;
   background-repeat: no-repeat;
-  width: 50px;
-  height: 70px;
+  width: var(--cell-size);
+  height: calc(var(--cell-size) * 1.4);
   z-index: 0;
 }
+
 .ponte2 {
   background-image: url(Imagens/ponte3.png);
   background-size: contain;
   background-repeat: no-repeat;
-  width: 50px;
-  height: 70px;
+  width: var(--cell-size);
+  height: calc(var(--cell-size) * 1.4);
   z-index: 0;
 }
 
@@ -130,7 +145,7 @@
   background-image: url(Imagens/placa.png);
   background-size: contain;
   background-repeat: no-repeat;
-  width: 50px;
-  height: 70px;
+  width: var(--cell-size);
+  height: calc(var(--cell-size) * 1.4);
   z-index: 0;
 }

--- a/app/jogo/Styles/StyleCelula.css
+++ b/app/jogo/Styles/StyleCelula.css
@@ -2,8 +2,16 @@
   position: relative;
   height: 50px;
   width: 43px;
+  display: flex;
   align-items: center;
   justify-content: center;
+  transition: transform 0.2s ease, filter 0.2s ease;
+}
+
+.Celula:hover,
+.Celula:focus-within {
+  transform: translateY(-2px);
+  filter: brightness(1.05);
 }
 
 .Celula > * {

--- a/app/jogo/Styles/StyleCelula.css
+++ b/app/jogo/Styles/StyleCelula.css
@@ -3,149 +3,135 @@
   width: var(--cell-size);
   height: var(--cell-height);
   display: flex;
-  align-items: center;
+  align-items: flex-end;
   justify-content: center;
-  transition: transform 0.2s ease, filter 0.2s ease;
   flex-shrink: 0;
-}
-
-.Celula:hover,
-.Celula:focus-within {
-  transform: translateY(-2px);
-  filter: brightness(1.05);
+  overflow: hidden;
 }
 
 .Celula > * {
   position: absolute;
-  z-index: 1;
+  left: 50%;
+  bottom: 0;
+  transform: translateX(-50%);
   pointer-events: none;
+  background-repeat: no-repeat;
+  background-position: center bottom;
+  image-rendering: auto;
 }
 
-.Celula > .caminho {
-  z-index: 0;
+.rio,
+.lama,
+.capim,
+.ponte1,
+.ponte2,
+.ponte3 {
+  left: 0;
+  bottom: 0;
+  transform: none;
+  width: 100%;
+  height: 100%;
+  background-position: center;
+  background-size: cover;
+  filter: none;
+}
+
+.arvore,
+.arvore2,
+.placa {
+  background-size: contain;
+  filter: drop-shadow(0 12px 18px rgba(0, 0, 0, 0.45));
+}
+
+.arvore,
+.arvore2 {
+  width: calc(var(--cell-size) * 1.3);
+  height: calc(var(--cell-size) * 1.85);
 }
 
 .arvore {
   background-image: url(Imagens/arvorenatal.png);
-  background-size: contain;
-  background-repeat: no-repeat;
-  width: var(--cell-size);
-  height: calc(var(--cell-size) * 1.6);
 }
 
 .arvore2 {
   background-image: url(Imagens/arvorenormal.png);
-  background-size: contain;
-  background-repeat: no-repeat;
-  width: calc(var(--cell-size) * 4);
+  width: calc(var(--cell-size) * 1.45);
   height: calc(var(--cell-size) * 2);
 }
 
 .capim {
   background-image: url(Imagens/capim.png);
-  background-size: contain;
-  background-repeat: no-repeat;
-  z-index: 2;
-  width: var(--cell-size);
-  height: calc(var(--cell-size) * 1.4);
-}
-
-.pedra {
-  border-radius: 20%;
-  background-image: url(Imagens/pedra.png);
-  background-size: cover;
-  width: calc(var(--cell-size) * 1.4);
-  height: calc(var(--cell-size) * 1.4);
 }
 
 .lama {
-  border-radius: 25%;
   background-image: url(Imagens/lama.png);
-  background-size: contain;
-  background-repeat: no-repeat;
-  z-index: 0;
-  width: var(--cell-size);
-  height: calc(var(--cell-size) * 1.4);
 }
 
 .rio {
-  border-radius: 0% 0% 10% 0%;
   background-image: url(Imagens/agua.png);
-  background-size: contain;
-  background-repeat: no-repeat;
-  z-index: 1;
-  width: var(--cell-size);
-  height: calc(var(--cell-size) * 1.4);
-}
-
-.castelo1 {
-  background-image: url(Imagens/castelo1.png);
-  background-size: contain;
-  background-repeat: no-repeat;
-  top: calc(var(--cell-size) * 0.08);
-  width: var(--cell-size);
-  height: calc(var(--cell-size) * 1.4);
-}
-
-.castelo2 {
-  background-image: url(Imagens/castelo2.png);
-  background-size: contain;
-  background-repeat: no-repeat;
-  right: calc(var(--cell-size) * -0.2);
-  width: var(--cell-size);
-  height: calc(var(--cell-size) * 1.4);
-}
-
-.castelo3 {
-  background-image: url(Imagens/castelo3.png);
-  background-size: contain;
-  background-repeat: no-repeat;
-  top: calc(var(--cell-size) * 0.08);
-  width: var(--cell-size);
-  height: calc(var(--cell-size) * 1.4);
-}
-
-.castelo4 {
-  background-image: url(Imagens/castelo4.png);
-  background-size: contain;
-  background-repeat: no-repeat;
-  right: calc(var(--cell-size) * -0.16);
-  width: var(--cell-size);
-  height: calc(var(--cell-size) * 2);
 }
 
 .ponte1 {
   background-image: url(Imagens/ponte1.png);
-  background-size: contain;
-  background-repeat: no-repeat;
-  width: var(--cell-size);
-  height: calc(var(--cell-size) * 1.4);
-  z-index: 0;
-}
-
-.ponte3 {
-  background-image: url(Imagens/ponte2.png);
-  background-size: contain;
-  background-repeat: no-repeat;
-  width: var(--cell-size);
-  height: calc(var(--cell-size) * 1.4);
-  z-index: 0;
 }
 
 .ponte2 {
   background-image: url(Imagens/ponte3.png);
+}
+
+.ponte3 {
+  background-image: url(Imagens/ponte2.png);
+}
+
+.pedra {
+  background-image: url(Imagens/pedra.png);
   background-size: contain;
-  background-repeat: no-repeat;
-  width: var(--cell-size);
-  height: calc(var(--cell-size) * 1.4);
-  z-index: 0;
+  width: calc(var(--cell-size) * 0.8);
+  height: calc(var(--cell-size) * 0.68);
+  bottom: calc(var(--cell-size) * 0.08);
+  filter: drop-shadow(0 10px 14px rgba(0, 0, 0, 0.45));
+}
+
+.castelo1,
+.castelo2,
+.castelo3,
+.castelo4 {
+  background-size: contain;
+  width: calc(var(--cell-size) * 1.35);
+  height: calc(var(--cell-size) * 2.05);
+  bottom: calc(var(--cell-size) * -0.08);
+}
+
+.castelo1,
+.castelo3 {
+  transform: translateX(-62%);
+}
+
+.castelo2,
+.castelo4 {
+  transform: translateX(-38%);
+}
+
+.castelo1 {
+  background-image: url(Imagens/castelo1.png);
+}
+
+.castelo2 {
+  background-image: url(Imagens/castelo2.png);
+}
+
+.castelo3 {
+  background-image: url(Imagens/castelo3.png);
+}
+
+.castelo4 {
+  background-image: url(Imagens/castelo4.png);
+  height: calc(var(--cell-size) * 2.2);
 }
 
 .placa {
   background-image: url(Imagens/placa.png);
-  background-size: contain;
-  background-repeat: no-repeat;
-  width: var(--cell-size);
-  height: calc(var(--cell-size) * 1.4);
-  z-index: 0;
+  width: calc(var(--cell-size) * 0.9);
+  height: calc(var(--cell-size) * 1.2);
+  bottom: calc(var(--cell-size) * -0.02);
 }

--- a/app/jogo/Styles/StyleRepGame.css
+++ b/app/jogo/Styles/StyleRepGame.css
@@ -10,715 +10,88 @@
 body {
   margin: 0;
   min-height: 100vh;
-  background: radial-gradient(
-      120% 120% at 50% 20%,
-      rgba(35, 70, 120, 0.55) 0%,
-      rgba(8, 16, 26, 0.85) 55%,
-      rgba(4, 8, 12, 0.95) 100%
-    ),
-    url("Imagens/imagemCastelo.PNG") center / cover fixed;
-  color: #f7f1e3;
+  background: radial-gradient(120% 120% at 50% 18%, #143248 0%, #040a11 70%);
+  color: #f4f7fb;
 }
 
 .game {
-  --game-padding-y: clamp(24px, 6vh, 72px);
-  --game-padding-x: clamp(16px, 5vw, 72px);
-  --game-panel-offset: clamp(16px, 4vw, 40px);
-  --game-panel-width: clamp(260px, 32vw, 380px);
-  --game-stage-width: clamp(420px, 72vw, 1320px);
-  --game-board-width: var(--game-stage-width);
+  --board-available-width: min(92vmin, 1180px);
   position: relative;
   min-height: 100vh;
   width: 100%;
-  padding: var(--game-padding-y) var(--game-padding-x);
   display: flex;
-  flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: clamp(24px, 4vw, 48px);
-  overflow: hidden;
-}
-
-.game__layer {
-  position: fixed;
-  inset: 0;
-  z-index: -1;
-  pointer-events: none;
-}
-
-.game__aurora {
-  position: absolute;
-  inset: -20vh -10vw;
-  background: radial-gradient(
-      60% 60% at 30% 20%,
-      rgba(47, 190, 255, 0.24),
-      transparent 70%
-    ),
-    radial-gradient(
-      60% 60% at 70% 40%,
-      rgba(146, 86, 255, 0.26),
-      transparent 75%
-    );
-  filter: blur(32px);
-  animation: auroraDrift 14s ease-in-out infinite alternate;
-}
-
-.game__particles {
-  position: absolute;
-  inset: 0;
-  overflow: hidden;
-}
-
-.game__particle {
-  position: absolute;
-  width: 14px;
-  height: 14px;
-  border-radius: 50%;
-  background: radial-gradient(circle, rgba(255, 255, 255, 0.85), transparent);
-  opacity: 0.7;
-  animation: particleFloat 12s linear infinite;
-}
-
-.game__particle--1 {
-  top: 12%;
-  left: 18%;
-  animation-delay: -2s;
-}
-
-.game__particle--2 {
-  top: 32%;
-  left: 78%;
-  animation-duration: 16s;
-}
-
-.game__particle--3 {
-  top: 68%;
-  left: 12%;
-  animation-delay: -6s;
-}
-
-.game__particle--4 {
-  top: 82%;
-  left: 62%;
-  animation-duration: 18s;
-}
-
-.game__particle--5 {
-  top: 44%;
-  left: 48%;
-  animation-delay: -9s;
-}
-
-.game__particle--6 {
-  top: 20%;
-  left: 52%;
-  animation-duration: 20s;
-}
-
-.game__particle--7 {
-  top: 74%;
-  left: 82%;
-  animation-delay: -12s;
-}
-
-.game__particle--8 {
-  top: 8%;
-  left: 64%;
-  animation-duration: 22s;
-}
-
-.game__particle--9 {
-  top: 52%;
-  left: 26%;
-  animation-delay: -4s;
-}
-
-.game__particle--10 {
-  top: 88%;
-  left: 34%;
-  animation-duration: 19s;
-}
-
-.game__particle--11 {
-  top: 60%;
-  left: 70%;
-  animation-delay: -16s;
-}
-
-.game__particle--12 {
-  top: 26%;
-  left: 8%;
-  animation-duration: 17s;
-}
-
-.game::before {
-  content: "";
-  position: fixed;
-  inset: 0;
-  background: linear-gradient(
-    180deg,
-    rgba(3, 10, 18, 0.55),
-    rgba(21, 9, 2, 0.7)
-  );
-  z-index: -1;
-}
-
-.start-panel {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 18px;
-  max-width: 420px;
-  padding: clamp(28px, 4vw, 40px);
-  border-radius: 28px;
-  background: linear-gradient(
-    145deg,
-    rgba(19, 38, 54, 0.92),
-    rgba(6, 14, 24, 0.9)
-  );
-  box-shadow: 0 25px 45px rgba(0, 0, 0, 0.55),
-    0 0 0 1px rgba(160, 215, 255, 0.18) inset;
-  text-align: center;
-  backdrop-filter: blur(8px);
-  animation: fadeInUp 0.8s ease forwards;
-}
-
-.start-panel__figure {
-  width: 120px;
-  height: 120px;
-  background-image: url("Imagens/perso.gif");
-  background-size: cover;
-  background-position: center;
-  border-radius: 24px;
-  box-shadow: 0 12px 26px rgba(0, 0, 0, 0.35);
-  animation: float 2.8s ease-in-out infinite;
-}
-
-.start-panel__title {
-  font-size: clamp(26px, 4vw, 36px);
-  font-weight: 700;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-}
-
-.start-panel__subtitle {
-  font-size: clamp(15px, 2.5vw, 18px);
-  color: rgba(225, 240, 255, 0.8);
-  line-height: 1.6;
-}
-
-.start-panel__tips {
-  margin: 0;
-  padding: 0;
-  display: grid;
-  gap: 8px;
-  list-style: none;
-  width: 100%;
-  color: rgba(220, 238, 255, 0.82);
-  font-size: clamp(13px, 2vw, 15px);
-}
-
-.start-panel__tips li::before {
-  content: "✦";
-  margin-right: 8px;
-  color: #4be1ff;
-}
-
-.start-panel__button {
-  margin-top: 8px;
-  padding: 14px 32px;
-  border-radius: 999px;
-  border: none;
-  background: linear-gradient(135deg, #4be1ff, #1d9ae2);
-  color: #04101a;
-  font-weight: 700;
-  font-size: 16px;
-  cursor: pointer;
-  box-shadow: 0 12px 25px rgba(18, 118, 196, 0.35);
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
-}
-
-.start-panel__button:hover {
-  transform: translateY(-2px) scale(1.02);
-  box-shadow: 0 16px 32px rgba(18, 118, 196, 0.5);
-}
-
-.hud {
-  position: fixed;
-  top: var(--game-panel-offset);
-  left: var(--game-panel-offset);
-  z-index: 3;
-  width: min(
-    var(--game-panel-width),
-    calc(100vw - (var(--game-panel-offset) * 2))
-  );
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: clamp(12px, 3vw, 28px);
-  padding: clamp(14px, 2.8vw, 24px);
-  border-radius: 20px;
-  background: rgba(8, 18, 28, 0.86);
-  border: 1px solid rgba(129, 203, 255, 0.24);
-  box-shadow: 0 18px 36px rgba(0, 0, 0, 0.48);
-  backdrop-filter: blur(8px);
-  flex-wrap: wrap;
-}
-
-.hud__stat {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-  min-width: 140px;
-}
-
-.hud__label {
-  font-size: 14px;
-  text-transform: uppercase;
-  letter-spacing: 0.12em;
-  color: rgba(188, 224, 255, 0.7);
-}
-
-.hud__value {
-  font-size: clamp(24px, 3vw, 32px);
-  font-weight: 700;
-  color: #fdf7e8;
-}
-
-.hud__value--success {
-  color: #54ffba;
-  text-shadow: 0 0 12px rgba(84, 255, 186, 0.5);
-}
-
-.hud__button {
-  padding: 12px 26px;
-  border-radius: 999px;
-  border: 1px solid rgba(113, 219, 255, 0.6);
-  background: transparent;
-  color: #dff6ff;
-  font-weight: 600;
-  cursor: pointer;
-  transition: background 0.25s ease, transform 0.2s ease;
-}
-
-.hud__button:hover {
-  background: rgba(54, 162, 235, 0.18);
-  transform: translateY(-2px);
+  padding: clamp(16px, 4vw, 48px);
 }
 
 .game__stage {
-  width: 100%;
+  --board-available-width: min(92vmin, 1180px);
+  width: min(92vmin, 1180px);
+  max-width: 100%;
   display: flex;
-  align-items: center;
   justify-content: center;
 }
 
-.board-wrapper {
-  --board-available-width: min(
-    var(--game-board-width, 100%),
-    calc(100vw - (var(--game-panel-offset) * 2)),
-    calc((100vh - (var(--game-panel-offset) * 2)) * 0.92)
-  );
-  width: var(--board-available-width);
-  max-width: var(--board-available-width);
-  min-width: min(320px, var(--board-available-width));
-  padding: clamp(20px, 2.6vw, 36px);
-  border-radius: 32px;
-  background: radial-gradient(
-      circle at top,
-      rgba(81, 201, 255, 0.12),
-      transparent 70%
-    )
-    rgba(6, 16, 24, 0.72);
-  box-shadow: 0 24px 52px rgba(0, 0, 0, 0.55);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  backdrop-filter: blur(4px);
-}
-
-.floating-panel {
-  position: fixed;
-  top: var(--game-panel-offset);
-  right: var(--game-panel-offset);
-  width: min(
-    var(--game-panel-width),
-    calc(100vw - (var(--game-panel-offset) * 2))
-  );
-  max-height: min(72vh, 640px);
-  padding: clamp(18px, 2.8vw, 28px);
-  border-radius: 24px;
-  display: flex;
-  flex-direction: column;
-  gap: clamp(12px, 2vw, 20px);
-  background: rgba(11, 28, 42, 0.82);
-  border: 1px solid rgba(103, 189, 255, 0.25);
-  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.5);
-  backdrop-filter: blur(12px);
-  overflow: hidden;
-  z-index: 3;
-}
-
-.floating-panel--compact {
-  width: min(240px, calc(100vw - (var(--game-panel-offset) * 2)));
-  max-height: min(58vh, 420px);
-  font-size: 0.94rem;
-}
-
-.floating-panel--expanded {
-  width: min(380px, calc(100vw - (var(--game-panel-offset) * 2)));
-  max-height: min(82vh, 720px);
-}
-
-.floating-panel__header {
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: 12px;
-}
-
-.floating-panel__title {
-  font-size: 20px;
-  font-weight: 600;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  margin: 0;
-}
-
-.floating-panel__actions {
-  display: flex;
-  gap: 8px;
-}
-
-.floating-panel__action {
-  appearance: none;
-  border: 1px solid rgba(113, 203, 255, 0.45);
-  background: rgba(21, 46, 68, 0.55);
-  color: #dff6ff;
-  border-radius: 999px;
-  padding: 8px 14px;
-  font-weight: 600;
-  font-size: 13px;
-  cursor: pointer;
-  transition: background 0.2s ease, transform 0.2s ease;
-}
-
-.floating-panel__action:hover {
-  background: rgba(54, 162, 235, 0.2);
-  transform: translateY(-1px);
-}
-
-.floating-panel__message {
-  line-height: 1.6;
-  color: rgba(222, 240, 255, 0.86);
-}
-
-.floating-panel__message--near {
-  color: #c7f2ff;
-  text-shadow: 0 0 14px rgba(97, 196, 255, 0.35);
-  transition: text-shadow 0.3s ease;
-}
-
-.floating-panel__message--calm {
-  color: rgba(198, 216, 255, 0.8);
-  font-style: italic;
-}
-
-.floating-panel__message--success {
-  color: #6cffdc;
-  text-shadow: 0 0 18px rgba(108, 255, 220, 0.55);
-  font-weight: 600;
-}
-
-.floating-panel__warning {
-  padding: 10px 14px;
-  border-radius: 14px;
-  background: rgba(255, 196, 108, 0.16);
-  border: 1px solid rgba(255, 193, 84, 0.45);
-  color: #ffd27f;
-  font-weight: 600;
-  animation: pulse 1s ease-in-out infinite alternate;
-}
-
-.floating-panel__progress {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-}
-
-.floating-panel__label {
-  font-size: 13px;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: rgba(172, 220, 255, 0.65);
-}
-
-.floating-panel__track {
-  position: relative;
-  height: 10px;
-  border-radius: 999px;
-  background: rgba(255, 255, 255, 0.08);
-  overflow: hidden;
-}
-
-.floating-panel__fill {
-  position: absolute;
-  inset: 0;
-  background: linear-gradient(135deg, #42ffb8, #46b1ff);
-  border-radius: 999px;
-  transition: width 0.35s ease-out;
-  box-shadow: 0 0 18px rgba(66, 255, 184, 0.45);
-}
-
-.floating-panel__hint {
-  font-size: 14px;
-  color: rgba(206, 235, 255, 0.85);
-}
-
-.floating-panel__tips {
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-  padding-left: 18px;
-  color: rgba(205, 228, 255, 0.78);
-  font-size: 15px;
-  line-height: 1.5;
-  overflow-y: auto;
-  flex: 1 1 auto;
-}
-
-.floating-panel__toggle {
-  position: fixed;
-  right: var(--game-panel-offset);
-  bottom: var(--game-panel-offset);
-  padding: 14px 24px;
-  border-radius: 999px;
-  background: rgba(21, 46, 68, 0.8);
-  color: #dff6ff;
-  border: 1px solid rgba(113, 203, 255, 0.5);
-  font-weight: 600;
-  cursor: pointer;
-  box-shadow: 0 16px 32px rgba(0, 0, 0, 0.45);
-  backdrop-filter: blur(8px);
-  transition: background 0.2s ease, transform 0.2s ease;
-  z-index: 3;
-}
-
-.floating-panel__toggle:hover {
-  background: rgba(54, 162, 235, 0.24);
-  transform: translateY(-2px);
-}
-
-.final {
+.game__overlay {
   position: fixed;
   inset: 0;
+  background: rgba(6, 14, 24, 0.72);
   display: flex;
   align-items: center;
   justify-content: center;
   padding: 24px;
-  background: rgba(3, 8, 12, 0.78);
-  backdrop-filter: blur(6px);
   z-index: 20;
 }
 
-.final__content {
+.game__overlay-card {
+  background: linear-gradient(160deg, rgba(14, 32, 46, 0.95), rgba(5, 12, 18, 0.92));
+  border: 1px solid rgba(120, 180, 220, 0.18);
+  border-radius: 24px;
+  padding: clamp(24px, 4vw, 40px);
+  text-align: center;
+  box-shadow: 0 22px 48px rgba(0, 0, 0, 0.55);
   max-width: 420px;
   width: 100%;
-  padding: clamp(28px, 4vw, 40px);
-  border-radius: 28px;
-  text-align: center;
-  background: linear-gradient(
-    160deg,
-    rgba(28, 60, 92, 0.95),
-    rgba(9, 16, 26, 0.92)
-  );
-  box-shadow: 0 24px 48px rgba(0, 0, 0, 0.55),
-    inset 0 0 0 1px rgba(167, 226, 255, 0.18);
-  animation: fadeInUp 0.6s ease forwards;
 }
 
-.final__title {
-  font-size: clamp(24px, 4vw, 32px);
-  margin-bottom: 12px;
+.game__overlay-title {
+  font-size: clamp(26px, 4vw, 34px);
+  margin: 0 0 12px;
 }
 
-.final__subtitle {
-  color: rgba(224, 243, 255, 0.78);
-  margin-bottom: 24px;
-  line-height: 1.5;
+.game__overlay-text {
+  margin: 0 0 24px;
+  color: rgba(233, 244, 255, 0.82);
+  font-size: clamp(16px, 2.4vw, 18px);
 }
 
-.final__button {
-  padding: 14px 30px;
-  border-radius: 999px;
+.game__overlay-button {
+  appearance: none;
   border: none;
-  background: linear-gradient(135deg, #f8d57a, #f19f3f);
-  color: #2b1600;
-  font-weight: 700;
+  border-radius: 999px;
+  background: linear-gradient(135deg, #2f9bff, #72f6ff);
+  color: #041018;
+  font-weight: 600;
+  font-size: 16px;
+  padding: 12px 28px;
   cursor: pointer;
-  box-shadow: 0 14px 26px rgba(241, 187, 71, 0.35);
   transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
-.final__button:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 18px 32px rgba(241, 187, 71, 0.5);
+.game__overlay-button:hover,
+.game__overlay-button:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 14px 32px rgba(47, 155, 255, 0.35);
 }
 
-@keyframes auroraDrift {
-  from {
-    transform: translate3d(-2%, -4%, 0) scale(1.02);
-  }
-  to {
-    transform: translate3d(3%, 6%, 0) scale(1.08);
-  }
-}
-
-@keyframes fadeInUp {
-  from {
-    opacity: 0;
-    transform: translateY(24px) scale(0.97);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0) scale(1);
-  }
-}
-
-@keyframes float {
-  0%,
-  100% {
-    transform: translateY(0);
-  }
-  50% {
-    transform: translateY(-10px);
-  }
-}
-
-@keyframes pulse {
-  from {
-    box-shadow: 0 0 0 rgba(255, 193, 84, 0.25);
-  }
-  to {
-    box-shadow: 0 0 18px rgba(255, 193, 84, 0.45);
-  }
-}
-
-@keyframes particleFloat {
-  0% {
-    transform: translate3d(0, 0, 0) scale(0.9);
-    opacity: 0.2;
-  }
-  25% {
-    opacity: 0.8;
-  }
-  50% {
-    transform: translate3d(10px, -30px, 0) scale(1.05);
-  }
-  75% {
-    opacity: 0.6;
-  }
-  100% {
-    transform: translate3d(-8px, -60px, 0) scale(0.8);
-    opacity: 0.2;
-  }
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .start-panel,
-  .final__content,
-  .floating-panel__fill,
-  .hud__button,
-  .start-panel__button,
-  .Celula,
-  .game__aurora,
-  .game__particle,
-  .floating-panel__warning,
-  .Personagem,
-  .objetivo {
-    animation-duration: 0.01ms !important;
-    animation-iteration-count: 1 !important;
-    transition-duration: 0.01ms !important;
-  }
-}
-
-@media (max-width: 1120px) {
+@media (max-width: 720px) {
   .game {
-    --game-panel-width: min(360px, 48vw);
-    --game-stage-width: clamp(420px, 82vw, 1200px);
+    padding: clamp(12px, 4vw, 24px);
   }
 
-  .floating-panel {
-    max-height: min(64vh, 520px);
-  }
-}
-
-@media (max-width: 900px) {
-  .hud {
-    left: 50%;
-    transform: translateX(-50%);
-    justify-content: center;
-    width: min(90vw, 520px);
-  }
-
-  .floating-panel,
-  .floating-panel--compact,
-  .floating-panel--expanded {
-    right: 50%;
-    left: auto;
-    transform: translateX(50%);
-    top: auto;
-    bottom: calc(var(--game-panel-offset) * 2.2);
-    width: min(90vw, 520px);
-    max-height: min(50vh, 420px);
-  }
-
-  .floating-panel__toggle {
-    right: 50%;
-    transform: translateX(50%);
-    bottom: var(--game-panel-offset);
-  }
-}
-
-@media (max-width: 768px) {
-  .game {
-    --game-padding-y: clamp(20px, 5vw, 32px);
-    --game-padding-x: clamp(12px, 5vw, 24px);
-    --game-stage-width: clamp(320px, 88vw, 960px);
-  }
-
-  .hud {
-    flex-direction: column;
-    align-items: stretch;
-    gap: clamp(12px, 3vw, 24px);
-  }
-
-  .hud__button {
-    width: 100%;
-  }
-
-  .floating-panel__actions {
-    flex-direction: column;
-  }
-}
-
-@media (max-width: 520px) {
-  .start-panel {
-    padding: 24px;
-  }
-
-  .start-panel__figure {
-    width: 96px;
-    height: 96px;
-  }
-
-  .floating-panel,
-  .floating-panel--compact,
-  .floating-panel--expanded {
-    width: min(92vw, 420px);
-  }
-
-  .floating-panel__toggle {
-    width: min(92vw, 420px);
+  .game__stage {
+    --board-available-width: min(96vw, 560px);
+    width: min(96vw, 560px);
   }
 }

--- a/app/jogo/Styles/StyleRepGame.css
+++ b/app/jogo/Styles/StyleRepGame.css
@@ -244,11 +244,14 @@ body {
   gap: clamp(16px, 4vw, 40px);
   padding: clamp(16px, 3vw, 24px);
   border-radius: 20px;
-  background: rgba(8, 18, 28, 0.75);
+  background: rgba(8, 18, 28, 0.82);
   border: 1px solid rgba(129, 203, 255, 0.18);
   box-shadow: 0 12px 28px rgba(0, 0, 0, 0.45);
   backdrop-filter: blur(6px);
   flex-wrap: wrap;
+  position: sticky;
+  top: clamp(12px, 3vw, 28px);
+  z-index: 2;
 }
 
 .hud__stat {
@@ -294,39 +297,43 @@ body {
 
 .game__content {
   width: 100%;
-  max-width: 1200px;
+  max-width: 1400px;
   display: flex;
-  align-items: stretch;
-  justify-content: center;
-  gap: clamp(22px, 5vw, 60px);
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: clamp(22px, 4vw, 56px);
   flex-wrap: wrap;
 }
 
 .board-wrapper {
-  padding: clamp(12px, 2vw, 18px);
+  flex: 1 1 720px;
+  max-width: 860px;
+  padding: clamp(16px, 2.5vw, 28px);
   border-radius: 28px;
   background: radial-gradient(
-    circle at top,
-    rgba(81, 201, 255, 0.08),
-    transparent 70%
-  );
-  box-shadow: 0 18px 35px rgba(0, 0, 0, 0.5);
+      circle at top,
+      rgba(81, 201, 255, 0.1),
+      transparent 70%
+    )
+    rgba(6, 16, 24, 0.72);
+  box-shadow: 0 22px 45px rgba(0, 0, 0, 0.55);
   display: flex;
   align-items: center;
   justify-content: center;
+  backdrop-filter: blur(4px);
 }
 
 .status-panel {
-  width: min(360px, 95vw);
+  flex: 0 1 clamp(260px, 25vw, 320px);
   padding: clamp(18px, 3vw, 26px);
   border-radius: 24px;
   display: flex;
   flex-direction: column;
   gap: 18px;
-  background: rgba(11, 28, 42, 0.82);
+  background: rgba(11, 28, 42, 0.78);
   border: 1px solid rgba(103, 189, 255, 0.2);
-  box-shadow: 0 16px 32px rgba(0, 0, 0, 0.48);
-  backdrop-filter: blur(6px);
+  box-shadow: 0 16px 32px rgba(0, 0, 0, 0.44);
+  backdrop-filter: blur(8px);
 }
 
 .status-panel__title {

--- a/app/jogo/Styles/StyleRepGame.css
+++ b/app/jogo/Styles/StyleRepGame.css
@@ -29,6 +29,119 @@ body {
   flex-direction: column;
   align-items: center;
   gap: clamp(24px, 4vw, 48px);
+  overflow: hidden;
+}
+
+.game__layer {
+  position: fixed;
+  inset: 0;
+  z-index: -1;
+  pointer-events: none;
+}
+
+.game__aurora {
+  position: absolute;
+  inset: -20vh -10vw;
+  background: radial-gradient(
+      60% 60% at 30% 20%,
+      rgba(47, 190, 255, 0.24),
+      transparent 70%
+    ),
+    radial-gradient(
+      60% 60% at 70% 40%,
+      rgba(146, 86, 255, 0.26),
+      transparent 75%
+    );
+  filter: blur(32px);
+  animation: auroraDrift 14s ease-in-out infinite alternate;
+}
+
+.game__particles {
+  position: absolute;
+  inset: 0;
+  overflow: hidden;
+}
+
+.game__particle {
+  position: absolute;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(255, 255, 255, 0.85), transparent);
+  opacity: 0.7;
+  animation: particleFloat 12s linear infinite;
+}
+
+.game__particle--1 {
+  top: 12%;
+  left: 18%;
+  animation-delay: -2s;
+}
+
+.game__particle--2 {
+  top: 32%;
+  left: 78%;
+  animation-duration: 16s;
+}
+
+.game__particle--3 {
+  top: 68%;
+  left: 12%;
+  animation-delay: -6s;
+}
+
+.game__particle--4 {
+  top: 82%;
+  left: 62%;
+  animation-duration: 18s;
+}
+
+.game__particle--5 {
+  top: 44%;
+  left: 48%;
+  animation-delay: -9s;
+}
+
+.game__particle--6 {
+  top: 20%;
+  left: 52%;
+  animation-duration: 20s;
+}
+
+.game__particle--7 {
+  top: 74%;
+  left: 82%;
+  animation-delay: -12s;
+}
+
+.game__particle--8 {
+  top: 8%;
+  left: 64%;
+  animation-duration: 22s;
+}
+
+.game__particle--9 {
+  top: 52%;
+  left: 26%;
+  animation-delay: -4s;
+}
+
+.game__particle--10 {
+  top: 88%;
+  left: 34%;
+  animation-duration: 19s;
+}
+
+.game__particle--11 {
+  top: 60%;
+  left: 70%;
+  animation-delay: -16s;
+}
+
+.game__particle--12 {
+  top: 26%;
+  left: 8%;
+  animation-duration: 17s;
 }
 
 .game::before {
@@ -85,6 +198,23 @@ body {
   font-size: clamp(15px, 2.5vw, 18px);
   color: rgba(225, 240, 255, 0.8);
   line-height: 1.6;
+}
+
+.start-panel__tips {
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 8px;
+  list-style: none;
+  width: 100%;
+  color: rgba(220, 238, 255, 0.82);
+  font-size: clamp(13px, 2vw, 15px);
+}
+
+.start-panel__tips li::before {
+  content: "✦";
+  margin-right: 8px;
+  color: #4be1ff;
 }
 
 .start-panel__button {
@@ -211,6 +341,23 @@ body {
   color: rgba(222, 240, 255, 0.86);
 }
 
+.status-panel__message--near {
+  color: #c7f2ff;
+  text-shadow: 0 0 14px rgba(97, 196, 255, 0.35);
+  transition: text-shadow 0.3s ease;
+}
+
+.status-panel__message--calm {
+  color: rgba(198, 216, 255, 0.8);
+  font-style: italic;
+}
+
+.status-panel__message--success {
+  color: #6cffdc;
+  text-shadow: 0 0 18px rgba(108, 255, 220, 0.55);
+  font-weight: 600;
+}
+
 .status-panel__warning {
   padding: 10px 14px;
   border-radius: 14px;
@@ -323,6 +470,15 @@ body {
   box-shadow: 0 18px 32px rgba(241, 187, 71, 0.5);
 }
 
+@keyframes auroraDrift {
+  from {
+    transform: translate3d(-2%, -4%, 0) scale(1.02);
+  }
+  to {
+    transform: translate3d(3%, 6%, 0) scale(1.08);
+  }
+}
+
 @keyframes fadeInUp {
   from {
     opacity: 0;
@@ -350,6 +506,44 @@ body {
   }
   to {
     box-shadow: 0 0 18px rgba(255, 193, 84, 0.45);
+  }
+}
+
+@keyframes particleFloat {
+  0% {
+    transform: translate3d(0, 0, 0) scale(0.9);
+    opacity: 0.2;
+  }
+  25% {
+    opacity: 0.8;
+  }
+  50% {
+    transform: translate3d(10px, -30px, 0) scale(1.05);
+  }
+  75% {
+    opacity: 0.6;
+  }
+  100% {
+    transform: translate3d(-8px, -60px, 0) scale(0.8);
+    opacity: 0.2;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .start-panel,
+  .final__content,
+  .progress__fill,
+  .hud__button,
+  .start-panel__button,
+  .Celula,
+  .game__aurora,
+  .game__particle,
+  .status-panel__warning,
+  .Personagem,
+  .objetivo {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
   }
 }
 

--- a/app/jogo/Styles/StyleRepGame.css
+++ b/app/jogo/Styles/StyleRepGame.css
@@ -306,9 +306,12 @@ body {
 }
 
 .board-wrapper {
-  flex: 1 1 70%;
-  min-width: min(70vw, 1040px);
-  max-width: min(88vw, 1240px);
+  --board-area-width: clamp(320px, 72vw, 1480px);
+  --board-available-width: min(var(--board-area-width), calc(100vw - 64px));
+  flex: 1 1 var(--board-available-width);
+  width: var(--board-available-width);
+  max-width: var(--board-available-width);
+  min-width: min(var(--board-available-width), clamp(280px, 56vw, 1200px));
   padding: clamp(18px, 2vw, 32px);
   border-radius: 32px;
   background: radial-gradient(

--- a/app/jogo/Styles/StyleRepGame.css
+++ b/app/jogo/Styles/StyleRepGame.css
@@ -21,10 +21,19 @@ body {
 }
 
 .game {
+  --game-padding-y: clamp(24px, 6vw, 64px);
+  --game-padding-x: clamp(16px, 5vw, 72px);
+  --game-gap: clamp(22px, 3vw, 52px);
+  --game-panel-width: clamp(260px, 26vw, 340px);
+  --game-board-area: clamp(360px, 72vw, 1480px);
+  --game-board-width: min(
+    var(--game-board-area),
+    calc(100vw - (var(--game-padding-x) * 2))
+  );
   position: relative;
   min-height: 100vh;
   width: 100%;
-  padding: clamp(24px, 6vw, 64px) clamp(16px, 5vw, 72px);
+  padding: var(--game-padding-y) var(--game-padding-x);
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -237,7 +246,8 @@ body {
 }
 
 .hud {
-  width: min(900px, 100%);
+  width: min(100%, var(--game-board-width, 100%));
+  max-width: min(100%, var(--game-board-width, 100%));
   display: flex;
   align-items: center;
   justify-content: center;
@@ -252,6 +262,7 @@ body {
   position: sticky;
   top: clamp(12px, 3vw, 28px);
   z-index: 2;
+  margin: 0 auto;
 }
 
 .hud__stat {
@@ -297,21 +308,24 @@ body {
 
 .game__content {
   width: 100%;
-  max-width: 1600px;
-  display: flex;
-  align-items: flex-start;
+  max-width: min(
+    100%,
+    calc(var(--game-board-width, 100%) + var(--game-gap) + var(--game-panel-width))
+  );
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, var(--game-panel-width));
+  align-items: start;
   justify-content: center;
-  gap: clamp(22px, 3vw, 52px);
-  flex-wrap: wrap;
+  gap: var(--game-gap);
+  margin: 0 auto;
 }
 
 .board-wrapper {
-  --board-area-width: clamp(320px, 72vw, 1480px);
-  --board-available-width: min(var(--board-area-width), calc(100vw - 64px));
+  --board-available-width: min(100%, var(--game-board-width, 100%));
   flex: 1 1 var(--board-available-width);
-  width: var(--board-available-width);
-  max-width: var(--board-available-width);
-  min-width: min(var(--board-available-width), clamp(280px, 56vw, 1200px));
+  width: min(100%, var(--game-board-width, 100%));
+  max-width: min(100%, var(--game-board-width, 100%));
+  min-width: min(100%, var(--game-board-width, 100%));
   padding: clamp(18px, 2vw, 32px);
   border-radius: 32px;
   background: radial-gradient(
@@ -325,12 +339,13 @@ body {
   align-items: center;
   justify-content: center;
   backdrop-filter: blur(4px);
+  justify-self: center;
 }
 
 .status-panel {
-  flex: 1 1 260px;
-  max-width: 340px;
-  width: min(28%, 340px);
+  flex: 1 1 var(--game-panel-width);
+  max-width: var(--game-panel-width);
+  width: min(100%, var(--game-panel-width));
   padding: clamp(18px, 3vw, 26px);
   border-radius: 24px;
   display: flex;
@@ -340,6 +355,7 @@ body {
   border: 1px solid rgba(103, 189, 255, 0.2);
   box-shadow: 0 16px 32px rgba(0, 0, 0, 0.44);
   backdrop-filter: blur(8px);
+  justify-self: center;
 }
 
 .status-panel__title {
@@ -567,26 +583,31 @@ body {
 }
 
 @media (max-width: 1120px) {
+  .game {
+    --game-panel-width: min(var(--game-board-width, 100%), clamp(280px, 52vw, 420px));
+  }
+
   .game__content {
-    flex-direction: column;
-    align-items: center;
+    grid-template-columns: minmax(0, 1fr);
+    max-width: min(100%, var(--game-board-width, 100%));
   }
 
   .board-wrapper {
-    min-width: min(92vw, 960px);
-    max-width: min(95vw, 1040px);
+    width: min(100%, var(--game-board-width, 100%));
   }
 
   .status-panel {
-    width: min(92vw, 440px);
-    max-width: none;
-    order: 2;
+    width: min(100%, var(--game-board-width, 100%));
+    max-width: min(100%, var(--game-board-width, 100%));
+    justify-self: center;
   }
 }
 
 @media (max-width: 768px) {
   .game {
-    padding: clamp(20px, 5vw, 32px) clamp(12px, 4vw, 24px);
+    --game-padding-y: clamp(20px, 5vw, 32px);
+    --game-padding-x: clamp(12px, 4vw, 24px);
+    --game-panel-width: min(100%, clamp(280px, 60vw, 420px));
   }
 
   .hud {
@@ -599,7 +620,7 @@ body {
   }
 
   .status-panel {
-    width: 100%;
+    width: min(100%, var(--game-board-width, 100%));
   }
 }
 

--- a/app/jogo/Styles/StyleRepGame.css
+++ b/app/jogo/Styles/StyleRepGame.css
@@ -1,221 +1,394 @@
-* {
-  margin: 0;
-  padding: 0;
-  box-sizing: border-box;
-  width: 100%;
+:root {
+  color-scheme: dark;
+  font-family: "Poppins", "Segoe UI", sans-serif;
 }
+
+* {
+  box-sizing: border-box;
+}
+
 body {
-  background-image: url('Imagens/imagemCastelo.PNG');
+  margin: 0;
+  min-height: 100vh;
+  background: radial-gradient(
+      120% 120% at 50% 20%,
+      rgba(35, 70, 120, 0.55) 0%,
+      rgba(8, 16, 26, 0.85) 55%,
+      rgba(4, 8, 12, 0.95) 100%
+    ),
+    url("Imagens/imagemCastelo.PNG") center / cover fixed;
+  color: #f7f1e3;
+}
+
+.game {
+  position: relative;
+  min-height: 100vh;
+  width: 100%;
+  padding: clamp(24px, 6vw, 64px) clamp(16px, 5vw, 72px);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: clamp(24px, 4vw, 48px);
+}
+
+.game::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  background: linear-gradient(
+    180deg,
+    rgba(3, 10, 18, 0.55),
+    rgba(21, 9, 2, 0.7)
+  );
+  z-index: -1;
+}
+
+.start-panel {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 18px;
+  max-width: 420px;
+  padding: clamp(28px, 4vw, 40px);
+  border-radius: 28px;
+  background: linear-gradient(
+    145deg,
+    rgba(19, 38, 54, 0.92),
+    rgba(6, 14, 24, 0.9)
+  );
+  box-shadow: 0 25px 45px rgba(0, 0, 0, 0.55),
+    0 0 0 1px rgba(160, 215, 255, 0.18) inset;
+  text-align: center;
+  backdrop-filter: blur(8px);
+  animation: fadeInUp 0.8s ease forwards;
+}
+
+.start-panel__figure {
+  width: 120px;
+  height: 120px;
+  background-image: url("Imagens/perso.gif");
   background-size: cover;
   background-position: center;
-  background-attachment: fixed;
-  image-rendering: pixelated;
-  image-orientation: from-image;
-  image-resolution: 300dpi;
-  min-height: 100vh;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  flex-direction: column;
-}
-.game {
-  width: 100%;
-  height: 60%;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  flex-direction: column;
-  transform: scale(1);
-  transform-origin: center;
-  overflow: hidden;
-  position: fixed;
-  top: 50%;
-  left: 50%;
-  transform: translate(-3%, -50%) scale(2);
+  border-radius: 24px;
+  box-shadow: 0 12px 26px rgba(0, 0, 0, 0.35);
+  animation: float 2.8s ease-in-out infinite;
 }
 
-
-.conteiner {
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-  text-align: center;
-  background-color: rgba(255, 255, 255, 0.9);
-  border-radius: 8px;
-  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
-  padding: 30px;
-  width: 320px;
-  height: 400px;
-  animation: fadeIn 1s forwards;
+.start-panel__title {
+  font-size: clamp(26px, 4vw, 36px);
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
 }
 
-.conteiner2 {
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-  text-align: center;
-  background-color: rgba(255, 255, 255, 0.9);
-  border-radius: 8px;
-  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
-  padding: 30px;
-  right: 23%;
-  top: 3%;
-  width:200px;
-  height: 220px;
-  animation: fadeIn 1s forwards;
-  position: relative;
+.start-panel__subtitle {
+  font-size: clamp(15px, 2.5vw, 18px);
+  color: rgba(225, 240, 255, 0.8);
+  line-height: 1.6;
 }
 
-@keyframes fadeIn {
-  0% {
-    opacity: 0;
-  }
-  100% {
-    opacity: 1;
-  }
-}
-
-.tituloJogo {
-  font-size: 10px;
-  color: #333;
-  margin-bottom: 15px;
-  line-height: normal;
-  font-weight: normal;
-  font-family: 'Courier New', Courier, monospace;
-  animation: slideUp 1s ease-in-out;
-}
-
-@keyframes slideUp {
-  0% {
-    transform: translateY(20px);
-    opacity: 0;
-  }
-  100% {
-    transform: translateY(0);
-    opacity: 1;
-  }
-}
-
-.linkjogo {
-  width: 100px;
-  height: 50px;
-  background-color: #3c7bad;
-  color: #fff;
+.start-panel__button {
+  margin-top: 8px;
+  padding: 14px 32px;
+  border-radius: 999px;
   border: none;
-  border-radius: 5px;
+  background: linear-gradient(135deg, #4be1ff, #1d9ae2);
+  color: #04101a;
+  font-weight: 700;
   font-size: 16px;
   cursor: pointer;
-  transition: background-color 0.3s ease, transform 0.3s ease;
+  box-shadow: 0 12px 25px rgba(18, 118, 196, 0.35);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
-.linkjogo:hover {
-  background-color: #21b7dc;
-  transform: scale(1.10);
+.start-panel__button:hover {
+  transform: translateY(-2px) scale(1.02);
+  box-shadow: 0 16px 32px rgba(18, 118, 196, 0.5);
 }
 
-.personagem {
-  width: 50px;
-  height: 50px;
-  background-image: url('Imagens/perso.gif');
-  background-size: cover;
-  background-position: center;
-  position: absolute;
-  top: 6%;
-}
-
-.contagem {
-  position: absolute;
-  top: 5%;
-  left: 5%;
-  color: rgb(14, 0, 0);
-  font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
-  font-size: 20px;
-  font-weight: bold;
-}
-
-.b1 {
-  width: 7%;
-  height: 6%;
-  left: 10%;
-  border-radius: 5px;
-  position: absolute;
-  color: white;
-  background-color: black;
-  font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
-  font-weight: bold;
-  transition: transform 0.3s;
-}
-
-.b1:hover {
-  transform: scale(1.2);
-}
-
-.reiniciar {
-  width: 30%;
-  height: 10%;
-  border-radius: 5px;
-  color: rgb(0, 0, 0);
-  position: absolute;
-  justify-items: center;
+.hud {
+  width: min(900px, 100%);
+  display: flex;
+  align-items: center;
   justify-content: center;
-  right: 50%;
-  top: 30%;
-  background-color: rgb(250, 250, 250);
-  font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
-  font-weight: bold;
-  cursor: pointer;
+  gap: clamp(16px, 4vw, 40px);
+  padding: clamp(16px, 3vw, 24px);
+  border-radius: 20px;
+  background: rgba(8, 18, 28, 0.75);
+  border: 1px solid rgba(129, 203, 255, 0.18);
+  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.45);
+  backdrop-filter: blur(6px);
+  flex-wrap: wrap;
 }
 
-.reiniciar:hover {
-  background-color: #ddd;
+.hud__stat {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-width: 140px;
+}
+
+.hud__label {
+  font-size: 14px;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: rgba(188, 224, 255, 0.7);
+}
+
+.hud__value {
+  font-size: clamp(24px, 3vw, 32px);
+  font-weight: 700;
+  color: #fdf7e8;
+}
+
+.hud__value--success {
+  color: #54ffba;
+  text-shadow: 0 0 12px rgba(84, 255, 186, 0.5);
+}
+
+.hud__button {
+  padding: 12px 26px;
+  border-radius: 999px;
+  border: 1px solid rgba(113, 219, 255, 0.6);
+  background: transparent;
+  color: #dff6ff;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.25s ease, transform 0.2s ease;
+}
+
+.hud__button:hover {
+  background: rgba(54, 162, 235, 0.18);
+  transform: translateY(-2px);
+}
+
+.game__content {
+  width: 100%;
+  max-width: 1200px;
+  display: flex;
+  align-items: stretch;
+  justify-content: center;
+  gap: clamp(22px, 5vw, 60px);
+  flex-wrap: wrap;
+}
+
+.board-wrapper {
+  padding: clamp(12px, 2vw, 18px);
+  border-radius: 28px;
+  background: radial-gradient(
+    circle at top,
+    rgba(81, 201, 255, 0.08),
+    transparent 70%
+  );
+  box-shadow: 0 18px 35px rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.status-panel {
+  width: min(360px, 95vw);
+  padding: clamp(18px, 3vw, 26px);
+  border-radius: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  background: rgba(11, 28, 42, 0.82);
+  border: 1px solid rgba(103, 189, 255, 0.2);
+  box-shadow: 0 16px 32px rgba(0, 0, 0, 0.48);
+  backdrop-filter: blur(6px);
+}
+
+.status-panel__title {
+  font-size: 20px;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.status-panel__message {
+  line-height: 1.6;
+  color: rgba(222, 240, 255, 0.86);
+}
+
+.status-panel__warning {
+  padding: 10px 14px;
+  border-radius: 14px;
+  background: rgba(255, 196, 108, 0.16);
+  border: 1px solid rgba(255, 193, 84, 0.45);
+  color: #ffd27f;
+  font-weight: 600;
+  animation: pulse 1s ease-in-out infinite alternate;
+}
+
+.status-panel__tips {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding-left: 18px;
+  color: rgba(205, 228, 255, 0.78);
+  font-size: 15px;
+  line-height: 1.5;
+}
+
+.progress {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.progress__label {
+  font-size: 13px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(172, 220, 255, 0.65);
+}
+
+.progress__track {
+  position: relative;
+  height: 10px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+  overflow: hidden;
+}
+
+.progress__fill {
+  position: absolute;
+  inset: 0;
+  width: 0;
+  background: linear-gradient(135deg, #42ffb8, #46b1ff);
+  border-radius: 999px;
+  transition: width 0.35s ease-out;
+  box-shadow: 0 0 18px rgba(66, 255, 184, 0.45);
+}
+
+.progress__hint {
+  font-size: 14px;
+  color: rgba(206, 235, 255, 0.85);
 }
 
 .final {
   position: fixed;
-  height: 40%;
-  width: 30%;
-  z-index: 3;
-  right: 53%; /* Ajustei para centralizar melhor na tela */
-  top: 25%;
+  inset: 0;
   display: flex;
-  justify-content: center;
   align-items: center;
-  background-image: url(Imagens/folha.jpg);
-  background-repeat: no-repeat;
-  background-size: contain;
+  justify-content: center;
+  padding: 24px;
+  background: rgba(3, 8, 12, 0.78);
+  backdrop-filter: blur(6px);
+  z-index: 20;
 }
 
-.textoFinal1 {
-  color: rgb(0, 0, 0);
-  font-size: 20px;
-  text-align: center; /* Ajustei para centralizar o texto */
-  padding-right: 30%;
-  width: 70%; /* Ajustei para ocupar toda a largura disponível */
+.final__content {
+  max-width: 420px;
+  width: 100%;
+  padding: clamp(28px, 4vw, 40px);
+  border-radius: 28px;
+  text-align: center;
+  background: linear-gradient(
+    160deg,
+    rgba(28, 60, 92, 0.95),
+    rgba(9, 16, 26, 0.92)
+  );
+  box-shadow: 0 24px 48px rgba(0, 0, 0, 0.55),
+    inset 0 0 0 1px rgba(167, 226, 255, 0.18);
+  animation: fadeInUp 0.6s ease forwards;
 }
 
-.textoFinal2 {
-  color: white;
-  font-size: 20px;
-  text-align: center; /* Ajustei para centralizar o texto */
-  padding-left: 25%;
-  width: 100%; /* Ajustei para ocupar toda a largura disponível */
+.final__title {
+  font-size: clamp(24px, 4vw, 32px);
+  margin-bottom: 12px;
+}
+
+.final__subtitle {
+  color: rgba(224, 243, 255, 0.78);
+  margin-bottom: 24px;
+  line-height: 1.5;
+}
+
+.final__button {
+  padding: 14px 30px;
+  border-radius: 999px;
+  border: none;
+  background: linear-gradient(135deg, #f8d57a, #f19f3f);
+  color: #2b1600;
+  font-weight: 700;
+  cursor: pointer;
+  box-shadow: 0 14px 26px rgba(241, 187, 71, 0.35);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.final__button:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 18px 32px rgba(241, 187, 71, 0.5);
+}
+
+@keyframes fadeInUp {
+  from {
+    opacity: 0;
+    transform: translateY(24px) scale(0.97);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+@keyframes float {
+  0%,
+  100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-10px);
+  }
+}
+
+@keyframes pulse {
+  from {
+    box-shadow: 0 0 0 rgba(255, 193, 84, 0.25);
+  }
+  to {
+    box-shadow: 0 0 18px rgba(255, 193, 84, 0.45);
+  }
+}
+
+@media (max-width: 900px) {
+  .hud {
+    justify-content: space-between;
+  }
 }
 
 @media (max-width: 768px) {
-  .conteiner {
-    width: 260px;
-    height: 350px;
-    padding: 20px;
+  .game {
+    padding: clamp(20px, 5vw, 32px) clamp(12px, 4vw, 24px);
   }
 
-  .tituloJogo {
-    font-size: 18px;
-    margin-bottom: 15px;
+  .hud {
+    flex-direction: column;
+    align-items: stretch;
   }
 
-  .linkjogo {
-    font-size: 14px;
+  .hud__button {
+    width: 100%;
+  }
+
+  .status-panel {
+    width: 100%;
+  }
+}
+
+@media (max-width: 520px) {
+  .start-panel {
+    padding: 24px;
+  }
+
+  .start-panel__figure {
+    width: 96px;
+    height: 96px;
+  }
+
+  .game__content {
+    gap: 18px;
   }
 }

--- a/app/jogo/Styles/StyleRepGame.css
+++ b/app/jogo/Styles/StyleRepGame.css
@@ -297,26 +297,27 @@ body {
 
 .game__content {
   width: 100%;
-  max-width: 1400px;
+  max-width: 1600px;
   display: flex;
   align-items: flex-start;
-  justify-content: space-between;
-  gap: clamp(22px, 4vw, 56px);
+  justify-content: center;
+  gap: clamp(22px, 3vw, 52px);
   flex-wrap: wrap;
 }
 
 .board-wrapper {
-  flex: 1 1 720px;
-  max-width: 860px;
-  padding: clamp(16px, 2.5vw, 28px);
-  border-radius: 28px;
+  flex: 1 1 70%;
+  min-width: min(70vw, 1040px);
+  max-width: min(88vw, 1240px);
+  padding: clamp(18px, 2vw, 32px);
+  border-radius: 32px;
   background: radial-gradient(
       circle at top,
-      rgba(81, 201, 255, 0.1),
+      rgba(81, 201, 255, 0.12),
       transparent 70%
     )
     rgba(6, 16, 24, 0.72);
-  box-shadow: 0 22px 45px rgba(0, 0, 0, 0.55);
+  box-shadow: 0 24px 52px rgba(0, 0, 0, 0.55);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -324,7 +325,9 @@ body {
 }
 
 .status-panel {
-  flex: 0 1 clamp(260px, 25vw, 320px);
+  flex: 1 1 260px;
+  max-width: 340px;
+  width: min(28%, 340px);
   padding: clamp(18px, 3vw, 26px);
   border-radius: 24px;
   display: flex;
@@ -557,6 +560,24 @@ body {
 @media (max-width: 900px) {
   .hud {
     justify-content: space-between;
+  }
+}
+
+@media (max-width: 1120px) {
+  .game__content {
+    flex-direction: column;
+    align-items: center;
+  }
+
+  .board-wrapper {
+    min-width: min(92vw, 960px);
+    max-width: min(95vw, 1040px);
+  }
+
+  .status-panel {
+    width: min(92vw, 440px);
+    max-width: none;
+    order: 2;
   }
 }
 

--- a/app/jogo/Styles/StyleRepGame.css
+++ b/app/jogo/Styles/StyleRepGame.css
@@ -21,15 +21,12 @@ body {
 }
 
 .game {
-  --game-padding-y: clamp(24px, 6vw, 64px);
+  --game-padding-y: clamp(24px, 6vh, 72px);
   --game-padding-x: clamp(16px, 5vw, 72px);
-  --game-gap: clamp(22px, 3vw, 52px);
-  --game-panel-width: clamp(260px, 26vw, 340px);
-  --game-board-area: clamp(360px, 72vw, 1480px);
-  --game-board-width: min(
-    var(--game-board-area),
-    calc(100vw - (var(--game-padding-x) * 2))
-  );
+  --game-panel-offset: clamp(16px, 4vw, 40px);
+  --game-panel-width: clamp(260px, 32vw, 380px);
+  --game-stage-width: clamp(420px, 72vw, 1320px);
+  --game-board-width: var(--game-stage-width);
   position: relative;
   min-height: 100vh;
   width: 100%;
@@ -37,6 +34,7 @@ body {
   display: flex;
   flex-direction: column;
   align-items: center;
+  justify-content: center;
   gap: clamp(24px, 4vw, 48px);
   overflow: hidden;
 }
@@ -246,23 +244,25 @@ body {
 }
 
 .hud {
-  width: min(100%, var(--game-board-width, 100%));
-  max-width: min(100%, var(--game-board-width, 100%));
+  position: fixed;
+  top: var(--game-panel-offset);
+  left: var(--game-panel-offset);
+  z-index: 3;
+  width: min(
+    var(--game-panel-width),
+    calc(100vw - (var(--game-panel-offset) * 2))
+  );
   display: flex;
   align-items: center;
-  justify-content: center;
-  gap: clamp(16px, 4vw, 40px);
-  padding: clamp(16px, 3vw, 24px);
+  justify-content: space-between;
+  gap: clamp(12px, 3vw, 28px);
+  padding: clamp(14px, 2.8vw, 24px);
   border-radius: 20px;
-  background: rgba(8, 18, 28, 0.82);
-  border: 1px solid rgba(129, 203, 255, 0.18);
-  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.45);
-  backdrop-filter: blur(6px);
+  background: rgba(8, 18, 28, 0.86);
+  border: 1px solid rgba(129, 203, 255, 0.24);
+  box-shadow: 0 18px 36px rgba(0, 0, 0, 0.48);
+  backdrop-filter: blur(8px);
   flex-wrap: wrap;
-  position: sticky;
-  top: clamp(12px, 3vw, 28px);
-  z-index: 2;
-  margin: 0 auto;
 }
 
 .hud__stat {
@@ -306,27 +306,23 @@ body {
   transform: translateY(-2px);
 }
 
-.game__content {
+.game__stage {
   width: 100%;
-  max-width: min(
-    100%,
-    calc(var(--game-board-width, 100%) + var(--game-gap) + var(--game-panel-width))
-  );
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(0, var(--game-panel-width));
-  align-items: start;
+  display: flex;
+  align-items: center;
   justify-content: center;
-  gap: var(--game-gap);
-  margin: 0 auto;
 }
 
 .board-wrapper {
-  --board-available-width: min(100%, var(--game-board-width, 100%));
-  flex: 1 1 var(--board-available-width);
-  width: min(100%, var(--game-board-width, 100%));
-  max-width: min(100%, var(--game-board-width, 100%));
-  min-width: min(100%, var(--game-board-width, 100%));
-  padding: clamp(18px, 2vw, 32px);
+  --board-available-width: min(
+    var(--game-board-width, 100%),
+    calc(100vw - (var(--game-panel-offset) * 2)),
+    calc((100vh - (var(--game-panel-offset) * 2)) * 0.92)
+  );
+  width: var(--board-available-width);
+  max-width: var(--board-available-width);
+  min-width: min(320px, var(--board-available-width));
+  padding: clamp(20px, 2.6vw, 36px);
   border-radius: 32px;
   background: radial-gradient(
       circle at top,
@@ -339,55 +335,102 @@ body {
   align-items: center;
   justify-content: center;
   backdrop-filter: blur(4px);
-  justify-self: center;
 }
 
-.status-panel {
-  flex: 1 1 var(--game-panel-width);
-  max-width: var(--game-panel-width);
-  width: min(100%, var(--game-panel-width));
-  padding: clamp(18px, 3vw, 26px);
+.floating-panel {
+  position: fixed;
+  top: var(--game-panel-offset);
+  right: var(--game-panel-offset);
+  width: min(
+    var(--game-panel-width),
+    calc(100vw - (var(--game-panel-offset) * 2))
+  );
+  max-height: min(72vh, 640px);
+  padding: clamp(18px, 2.8vw, 28px);
   border-radius: 24px;
   display: flex;
   flex-direction: column;
-  gap: 18px;
-  background: rgba(11, 28, 42, 0.78);
-  border: 1px solid rgba(103, 189, 255, 0.2);
-  box-shadow: 0 16px 32px rgba(0, 0, 0, 0.44);
-  backdrop-filter: blur(8px);
-  justify-self: center;
+  gap: clamp(12px, 2vw, 20px);
+  background: rgba(11, 28, 42, 0.82);
+  border: 1px solid rgba(103, 189, 255, 0.25);
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.5);
+  backdrop-filter: blur(12px);
+  overflow: hidden;
+  z-index: 3;
 }
 
-.status-panel__title {
+.floating-panel--compact {
+  width: min(240px, calc(100vw - (var(--game-panel-offset) * 2)));
+  max-height: min(58vh, 420px);
+  font-size: 0.94rem;
+}
+
+.floating-panel--expanded {
+  width: min(380px, calc(100vw - (var(--game-panel-offset) * 2)));
+  max-height: min(82vh, 720px);
+}
+
+.floating-panel__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.floating-panel__title {
   font-size: 20px;
   font-weight: 600;
-  letter-spacing: 0.05em;
+  letter-spacing: 0.08em;
   text-transform: uppercase;
+  margin: 0;
 }
 
-.status-panel__message {
+.floating-panel__actions {
+  display: flex;
+  gap: 8px;
+}
+
+.floating-panel__action {
+  appearance: none;
+  border: 1px solid rgba(113, 203, 255, 0.45);
+  background: rgba(21, 46, 68, 0.55);
+  color: #dff6ff;
+  border-radius: 999px;
+  padding: 8px 14px;
+  font-weight: 600;
+  font-size: 13px;
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.floating-panel__action:hover {
+  background: rgba(54, 162, 235, 0.2);
+  transform: translateY(-1px);
+}
+
+.floating-panel__message {
   line-height: 1.6;
   color: rgba(222, 240, 255, 0.86);
 }
 
-.status-panel__message--near {
+.floating-panel__message--near {
   color: #c7f2ff;
   text-shadow: 0 0 14px rgba(97, 196, 255, 0.35);
   transition: text-shadow 0.3s ease;
 }
 
-.status-panel__message--calm {
+.floating-panel__message--calm {
   color: rgba(198, 216, 255, 0.8);
   font-style: italic;
 }
 
-.status-panel__message--success {
+.floating-panel__message--success {
   color: #6cffdc;
   text-shadow: 0 0 18px rgba(108, 255, 220, 0.55);
   font-weight: 600;
 }
 
-.status-panel__warning {
+.floating-panel__warning {
   padding: 10px 14px;
   border-radius: 14px;
   background: rgba(255, 196, 108, 0.16);
@@ -397,30 +440,20 @@ body {
   animation: pulse 1s ease-in-out infinite alternate;
 }
 
-.status-panel__tips {
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-  padding-left: 18px;
-  color: rgba(205, 228, 255, 0.78);
-  font-size: 15px;
-  line-height: 1.5;
-}
-
-.progress {
+.floating-panel__progress {
   display: flex;
   flex-direction: column;
   gap: 8px;
 }
 
-.progress__label {
+.floating-panel__label {
   font-size: 13px;
   letter-spacing: 0.08em;
   text-transform: uppercase;
   color: rgba(172, 220, 255, 0.65);
 }
 
-.progress__track {
+.floating-panel__track {
   position: relative;
   height: 10px;
   border-radius: 999px;
@@ -428,19 +461,52 @@ body {
   overflow: hidden;
 }
 
-.progress__fill {
+.floating-panel__fill {
   position: absolute;
   inset: 0;
-  width: 0;
   background: linear-gradient(135deg, #42ffb8, #46b1ff);
   border-radius: 999px;
   transition: width 0.35s ease-out;
   box-shadow: 0 0 18px rgba(66, 255, 184, 0.45);
 }
 
-.progress__hint {
+.floating-panel__hint {
   font-size: 14px;
   color: rgba(206, 235, 255, 0.85);
+}
+
+.floating-panel__tips {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding-left: 18px;
+  color: rgba(205, 228, 255, 0.78);
+  font-size: 15px;
+  line-height: 1.5;
+  overflow-y: auto;
+  flex: 1 1 auto;
+}
+
+.floating-panel__toggle {
+  position: fixed;
+  right: var(--game-panel-offset);
+  bottom: var(--game-panel-offset);
+  padding: 14px 24px;
+  border-radius: 999px;
+  background: rgba(21, 46, 68, 0.8);
+  color: #dff6ff;
+  border: 1px solid rgba(113, 203, 255, 0.5);
+  font-weight: 600;
+  cursor: pointer;
+  box-shadow: 0 16px 32px rgba(0, 0, 0, 0.45);
+  backdrop-filter: blur(8px);
+  transition: background 0.2s ease, transform 0.2s ease;
+  z-index: 3;
+}
+
+.floating-panel__toggle:hover {
+  background: rgba(54, 162, 235, 0.24);
+  transform: translateY(-2px);
 }
 
 .final {
@@ -561,13 +627,13 @@ body {
 @media (prefers-reduced-motion: reduce) {
   .start-panel,
   .final__content,
-  .progress__fill,
+  .floating-panel__fill,
   .hud__button,
   .start-panel__button,
   .Celula,
   .game__aurora,
   .game__particle,
-  .status-panel__warning,
+  .floating-panel__warning,
   .Personagem,
   .objetivo {
     animation-duration: 0.01ms !important;
@@ -576,51 +642,63 @@ body {
   }
 }
 
-@media (max-width: 900px) {
-  .hud {
-    justify-content: space-between;
+@media (max-width: 1120px) {
+  .game {
+    --game-panel-width: min(360px, 48vw);
+    --game-stage-width: clamp(420px, 82vw, 1200px);
+  }
+
+  .floating-panel {
+    max-height: min(64vh, 520px);
   }
 }
 
-@media (max-width: 1120px) {
-  .game {
-    --game-panel-width: min(var(--game-board-width, 100%), clamp(280px, 52vw, 420px));
+@media (max-width: 900px) {
+  .hud {
+    left: 50%;
+    transform: translateX(-50%);
+    justify-content: center;
+    width: min(90vw, 520px);
   }
 
-  .game__content {
-    grid-template-columns: minmax(0, 1fr);
-    max-width: min(100%, var(--game-board-width, 100%));
+  .floating-panel,
+  .floating-panel--compact,
+  .floating-panel--expanded {
+    right: 50%;
+    left: auto;
+    transform: translateX(50%);
+    top: auto;
+    bottom: calc(var(--game-panel-offset) * 2.2);
+    width: min(90vw, 520px);
+    max-height: min(50vh, 420px);
   }
 
-  .board-wrapper {
-    width: min(100%, var(--game-board-width, 100%));
-  }
-
-  .status-panel {
-    width: min(100%, var(--game-board-width, 100%));
-    max-width: min(100%, var(--game-board-width, 100%));
-    justify-self: center;
+  .floating-panel__toggle {
+    right: 50%;
+    transform: translateX(50%);
+    bottom: var(--game-panel-offset);
   }
 }
 
 @media (max-width: 768px) {
   .game {
     --game-padding-y: clamp(20px, 5vw, 32px);
-    --game-padding-x: clamp(12px, 4vw, 24px);
-    --game-panel-width: min(100%, clamp(280px, 60vw, 420px));
+    --game-padding-x: clamp(12px, 5vw, 24px);
+    --game-stage-width: clamp(320px, 88vw, 960px);
   }
 
   .hud {
     flex-direction: column;
     align-items: stretch;
+    gap: clamp(12px, 3vw, 24px);
   }
 
   .hud__button {
     width: 100%;
   }
 
-  .status-panel {
-    width: min(100%, var(--game-board-width, 100%));
+  .floating-panel__actions {
+    flex-direction: column;
   }
 }
 
@@ -634,7 +712,13 @@ body {
     height: 96px;
   }
 
-  .game__content {
-    gap: 18px;
+  .floating-panel,
+  .floating-panel--compact,
+  .floating-panel--expanded {
+    width: min(92vw, 420px);
+  }
+
+  .floating-panel__toggle {
+    width: min(92vw, 420px);
   }
 }

--- a/app/jogo/Styles/StyleTabuleiro.css
+++ b/app/jogo/Styles/StyleTabuleiro.css
@@ -1,36 +1,24 @@
 .board {
   --board-columns: 21;
-  --board-padding: clamp(18px, 2.5vw, 32px);
-  --board-width: var(--board-available-width, calc(100vw - 64px));
+  --board-padding: clamp(12px, 2.2vw, 28px);
+  --board-width: var(--board-available-width, min(92vmin, 1100px));
   --cell-size: min(
-    64px,
+    68px,
     calc((var(--board-width) - var(--board-padding)) / var(--board-columns))
   );
-  --cell-height: calc(var(--cell-size) * 1.16);
-  width: 100%;
-  max-width: 100%;
-  display: inline-flex;
+  --cell-height: calc(var(--cell-size) * 1.05);
+  width: min(var(--board-width), 100%);
+  display: flex;
   flex-direction: column;
   gap: 0;
   padding: calc(var(--board-padding) / 2);
-  border-radius: 24px;
-  border: 3px solid rgba(84, 56, 12, 0.65);
-  background: linear-gradient(145deg, rgba(18, 44, 32, 0.95), rgba(9, 24, 17, 0.92));
-  box-shadow: 0 18px 35px rgba(0, 0, 0, 0.45), inset 0 0 0 1px rgba(255, 255, 255, 0.04);
-  image-rendering: pixelated;
-  backdrop-filter: blur(2px);
-  animation: boardGlow 6s ease-in-out infinite alternate;
+  border-radius: 22px;
+  border: 2px solid rgba(40, 104, 82, 0.65);
+  background: linear-gradient(165deg, rgba(8, 24, 16, 0.94), rgba(4, 12, 9, 0.92));
+  box-shadow: 0 26px 48px rgba(0, 0, 0, 0.45);
+  overflow: hidden;
 }
 
 .board__row {
   display: flex;
-}
-
-@keyframes boardGlow {
-  0% {
-    box-shadow: 0 18px 35px rgba(0, 0, 0, 0.45), inset 0 0 0 1px rgba(255, 255, 255, 0.04);
-  }
-  100% {
-    box-shadow: 0 22px 45px rgba(0, 0, 0, 0.6), inset 0 0 15px rgba(87, 206, 255, 0.15);
-  }
 }

--- a/app/jogo/Styles/StyleTabuleiro.css
+++ b/app/jogo/Styles/StyleTabuleiro.css
@@ -1,4 +1,6 @@
 .board {
+  --cell-size: clamp(44px, 3.35vw, 68px);
+  --cell-height: calc(var(--cell-size) * 1.16);
   display: inline-flex;
   flex-direction: column;
   gap: 0;

--- a/app/jogo/Styles/StyleTabuleiro.css
+++ b/app/jogo/Styles/StyleTabuleiro.css
@@ -1,30 +1,26 @@
-html, body {
-  margin: 0;
-  padding: 0;
-  height: 100%;
-  background-color: #1a1a1a;
-  font-family: 'Courier New', monospace;
-  overflow: hidden; /* Evita barra de rolagem indesejada */
-}
-
-/* Container do tabuleiro centralizado e cobrindo toda a tela */
-.container {
-  display: flex;
+.board {
+  display: inline-flex;
   flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  
-  width: 100vw;
-  height: 100vh;
-  
-  background-image: url("Imagens/grass.png");
-  background-repeat: repeat;
-  background-size: 32px 32px; /* Ajuste ao tamanho da célula */
+  gap: 0;
+  padding: 12px;
+  border-radius: 24px;
+  border: 3px solid rgba(84, 56, 12, 0.65);
+  background: linear-gradient(145deg, rgba(18, 44, 32, 0.95), rgba(9, 24, 17, 0.92));
+  box-shadow: 0 18px 35px rgba(0, 0, 0, 0.45), inset 0 0 0 1px rgba(255, 255, 255, 0.04);
   image-rendering: pixelated;
+  backdrop-filter: blur(2px);
+  animation: boardGlow 6s ease-in-out infinite alternate;
 }
 
-/* Cada linha do tabuleiro */
-.mostralinha {
+.board__row {
   display: flex;
-  flex-direction: row;
+}
+
+@keyframes boardGlow {
+  0% {
+    box-shadow: 0 18px 35px rgba(0, 0, 0, 0.45), inset 0 0 0 1px rgba(255, 255, 255, 0.04);
+  }
+  100% {
+    box-shadow: 0 22px 45px rgba(0, 0, 0, 0.6), inset 0 0 15px rgba(87, 206, 255, 0.15);
+  }
 }

--- a/app/jogo/Styles/StyleTabuleiro.css
+++ b/app/jogo/Styles/StyleTabuleiro.css
@@ -1,6 +1,6 @@
 .board {
   --board-columns: 21;
-  --board-padding: 24px;
+  --board-padding: clamp(18px, 2.5vw, 32px);
   --board-width: var(--board-available-width, calc(100vw - 64px));
   --cell-size: min(
     64px,

--- a/app/jogo/Styles/StyleTabuleiro.css
+++ b/app/jogo/Styles/StyleTabuleiro.css
@@ -1,10 +1,18 @@
 .board {
-  --cell-size: clamp(44px, 3.35vw, 68px);
+  --board-columns: 21;
+  --board-padding: 24px;
+  --board-width: var(--board-available-width, calc(100vw - 64px));
+  --cell-size: min(
+    64px,
+    calc((var(--board-width) - var(--board-padding)) / var(--board-columns))
+  );
   --cell-height: calc(var(--cell-size) * 1.16);
+  width: 100%;
+  max-width: 100%;
   display: inline-flex;
   flex-direction: column;
   gap: 0;
-  padding: 12px;
+  padding: calc(var(--board-padding) / 2);
   border-radius: 24px;
   border: 3px solid rgba(84, 56, 12, 0.65);
   background: linear-gradient(145deg, rgba(18, 44, 32, 0.95), rgba(9, 24, 17, 0.92));

--- a/app/jogo/Styles/StyleTelaPrincipal.css
+++ b/app/jogo/Styles/StyleTelaPrincipal.css
@@ -20,7 +20,7 @@ body {
 }
 
 /* Container principal */
-.conteiner {
+.container {
   position: relative;
   display: flex;
   flex-direction: column;
@@ -121,7 +121,7 @@ body {
   }
 }
 @media (max-width: 480px) {
-  .conteiner {
+  .container {
     width: 90%;
     max-width: 300px;
     min-height: auto;

--- a/app/jogo/Tabuleiro.jsx
+++ b/app/jogo/Tabuleiro.jsx
@@ -1,6 +1,14 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useMemo } from "react";
 import Celula from "./celula";
 import "./Styles/StyleTabuleiro.css";
+
+const toTileMap = (tiles = []) => {
+  const map = new Map();
+  tiles.forEach(([x, y, tipo]) => {
+    map.set(`${x}-${y}`, tipo);
+  });
+  return map;
+};
 
 export default function Tabuleiro({
   jogador,
@@ -13,25 +21,31 @@ export default function Tabuleiro({
   const tamanhoMapa = 80;
   const raioVisao = 10;
 
-  const centralizarVisao = useCallback(([posX, posY]) => {
-    if (posX == null || posY == null) return;
+  const obstaculosMap = useMemo(() => toTileMap(obst), [obst]);
+  const terrenosMap = useMemo(() => toTileMap(LamaCapim), [LamaCapim]);
 
-    const novaVisao = [];
-    const inicioX = Math.max(0, posX - raioVisao);
-    const fimX = Math.min(tamanhoMapa - 1, posX + raioVisao);
-    const inicioY = Math.max(0, posY - raioVisao);
-    const fimY = Math.min(tamanhoMapa - 1, posY + raioVisao);
+  const centralizarVisao = useCallback(
+    ([posX, posY]) => {
+      if (posX == null || posY == null) return;
 
-    for (let i = inicioX; i <= fimX; i++) {
-      const linha = [];
-      for (let j = inicioY; j <= fimY; j++) {
-        linha.push([i, j]);
+      const novaVisao = [];
+      const inicioX = Math.max(0, posX - raioVisao);
+      const fimX = Math.min(tamanhoMapa - 1, posX + raioVisao);
+      const inicioY = Math.max(0, posY - raioVisao);
+      const fimY = Math.min(tamanhoMapa - 1, posY + raioVisao);
+
+      for (let i = inicioX; i <= fimX; i++) {
+        const linha = [];
+        for (let j = inicioY; j <= fimY; j++) {
+          linha.push([i, j]);
+        }
+        novaVisao.push(linha);
       }
-      novaVisao.push(linha);
-    }
 
-    setVisao(novaVisao);
-  }, [tamanhoMapa, raioVisao]);
+      setVisao(novaVisao);
+    },
+    [tamanhoMapa, raioVisao]
+  );
 
   useEffect(() => {
     if (jogador && jogador.length === 2) {
@@ -49,9 +63,9 @@ export default function Tabuleiro({
               coords={[x, y]}
               jogador={jogador}
               objetivo={obj}
-              obst={obst}
+              obstMap={obstaculosMap}
               reiniciarJogo={reiniciarJogo}
-              LamaCapim={LamaCapim}
+              terrenosMap={terrenosMap}
             />
           ))}
         </div>

--- a/app/jogo/Tabuleiro.jsx
+++ b/app/jogo/Tabuleiro.jsx
@@ -2,7 +2,13 @@ import { useState, useEffect, useCallback } from "react";
 import Celula from "./celula";
 import "./Styles/StyleTabuleiro.css";
 
-export default function Tabuleiro({ jogador, obj, obst, reiniciarJogo, LamaCapim }) {
+export default function Tabuleiro({
+  jogador,
+  obj,
+  obst,
+  reiniciarJogo,
+  LamaCapim,
+}) {
   const [visao, setVisao] = useState([]);
   const tamanhoMapa = 80;
   const raioVisao = 8;
@@ -34,9 +40,9 @@ export default function Tabuleiro({ jogador, obj, obst, reiniciarJogo, LamaCapim
   }, [jogador, centralizarVisao]);
 
   return (
-    <div className="container">
+    <div className="board">
       {visao.map((linha, i) => (
-        <div key={i} className="mostralinha">
+        <div key={i} className="board__row">
           {linha.map(([x, y]) => (
             <Celula
               key={`${x}-${y}`}

--- a/app/jogo/Tabuleiro.jsx
+++ b/app/jogo/Tabuleiro.jsx
@@ -53,8 +53,14 @@ export default function Tabuleiro({
     }
   }, [jogador, centralizarVisao]);
 
+  const colunasVisiveis = visao[0]?.length ?? 0;
+  const boardStyle = useMemo(
+    () => ({ "--board-columns": `${Math.max(colunasVisiveis, 1)}` }),
+    [colunasVisiveis]
+  );
+
   return (
-    <div className="board">
+    <div className="board" style={boardStyle}>
       {visao.map((linha, i) => (
         <div key={i} className="board__row">
           {linha.map(([x, y]) => (

--- a/app/jogo/Tabuleiro.jsx
+++ b/app/jogo/Tabuleiro.jsx
@@ -11,7 +11,7 @@ export default function Tabuleiro({
 }) {
   const [visao, setVisao] = useState([]);
   const tamanhoMapa = 80;
-  const raioVisao = 8;
+  const raioVisao = 10;
 
   const centralizarVisao = useCallback(([posX, posY]) => {
     if (posX == null || posY == null) return;

--- a/app/jogo/TelaInicial.jsx
+++ b/app/jogo/TelaInicial.jsx
@@ -11,6 +11,11 @@ export default function TelaInicial({ iniciarJogo }) {
         Ajude Stuart a recuperar a Excalibur no labirinto mágico e escapar das
         armadilhas da floresta.
       </p>
+      <ul className="start-panel__tips">
+        <li>Movimente-se com as setas do teclado.</li>
+        <li>Evite rios e pedras enquanto procura a Excalibur.</li>
+        <li>Volte ao castelo quando encontrar a espada lendária.</li>
+      </ul>
       <button className="start-panel__button" onClick={iniciarJogo}>
         Iniciar aventura
       </button>

--- a/app/jogo/TelaInicial.jsx
+++ b/app/jogo/TelaInicial.jsx
@@ -4,12 +4,16 @@ import "./Styles/StyleRepGame.css";
 
 export default function TelaInicial({ iniciarJogo }) {
   return (
-    <div className="conteiner2">
-      <h1 className="tituloJogo">Stuart e o castelo perdido!</h1>
-      <button className="linkjogo" onClick={iniciarJogo}>
-        Entrar
+    <div className="start-panel">
+      <div className="start-panel__figure" aria-hidden="true" />
+      <h1 className="start-panel__title">Stuart e o Castelo Perdido</h1>
+      <p className="start-panel__subtitle">
+        Ajude Stuart a recuperar a Excalibur no labirinto mágico e escapar das
+        armadilhas da floresta.
+      </p>
+      <button className="start-panel__button" onClick={iniciarJogo}>
+        Iniciar aventura
       </button>
-      <div className="personagem"></div>
     </div>
   );
 }

--- a/app/jogo/TelaPrincipal.jsx
+++ b/app/jogo/TelaPrincipal.jsx
@@ -13,12 +13,12 @@ export default function TelaPrincipal() {
   return (
     <div>
       {!iniciarJogo ? (
-        <div className="conteiner">
-           <div className="personagem"></div>
-            <h3 className="tituloJogo">Stuart e o castelo perdido!</h3>
-            <button className="linkjogo" onClick={iniciar}>
-                Entrar
-            </button>
+        <div className="container">
+          <div className="personagem" />
+          <h3 className="tituloJogo">Stuart e o castelo perdido!</h3>
+          <button className="linkjogo" onClick={iniciar}>
+            Entrar
+          </button>
         </div>
       ) : (
         <RepGame />

--- a/app/jogo/celula.jsx
+++ b/app/jogo/celula.jsx
@@ -2,188 +2,162 @@ import Objetivo from "./Obj_Perso/Objetivo";
 import Personagem from "./Obj_Perso/Personagem";
 import "./Styles/StyleCelula.css";
 
+const coordKey = (x, y) => `${x}-${y}`;
+
+const createRectSet = (...rects) => {
+  const set = new Set();
+  rects.forEach(([xIni, xFim, yIni, yFim]) => {
+    for (let x = xIni; x < xFim; x++) {
+      for (let y = yIni; y < yFim; y++) {
+        set.add(coordKey(x, y));
+      }
+    }
+  });
+  return set;
+};
+
+const mergeSets = (...sets) => {
+  const merged = new Set();
+  sets.forEach((set) => {
+    set.forEach((value) => merged.add(value));
+  });
+  return merged;
+};
+
+const RIVER_TILES = createRectSet([0, 10, 0, 12]);
+const CASTLE_RIVER_TILES = createRectSet(
+  [5, 10, 10, 23],
+  [5, 10, 27, 48]
+);
+
+const PATH_TILE_SETS = {
+  ponte1: createRectSet([5, 10, 23, 24]),
+  ponte2: createRectSet([5, 10, 24, 26]),
+  ponte3: createRectSet([5, 10, 26, 27]),
+};
+
+const PATH_TILE_CLASS = new Map();
+Object.entries(PATH_TILE_SETS).forEach(([className, set]) => {
+  set.forEach((key) => PATH_TILE_CLASS.set(key, className));
+});
+
+const TREE_BORDERS = createRectSet([0, 3, 10, 80], [10, 80, 0, 3]);
+const TREE_DEPTH = createRectSet([10, 48, 3, 10]);
+const TREE_RING = createRectSet([48, 80, 0, 50], [0, 50, 48, 80]);
+const TREE_TILES = mergeSets(TREE_BORDERS, TREE_DEPTH, TREE_RING);
+
+const CASTLE_TILES = new Map([
+  [coordKey(4, 24), "castelo1"],
+  [coordKey(3, 24), "castelo2"],
+  [coordKey(4, 25), "castelo3"],
+  [coordKey(3, 25), "castelo4"],
+]);
+
+const SIGN_TILE_KEY = coordKey(10, 22);
+
+const STATIC_BLOCKERS = mergeSets(
+  RIVER_TILES,
+  CASTLE_RIVER_TILES,
+  PATH_TILE_SETS.ponte1,
+  PATH_TILE_SETS.ponte2,
+  PATH_TILE_SETS.ponte3,
+  TREE_TILES,
+  new Set(CASTLE_TILES.keys()),
+  new Set([SIGN_TILE_KEY])
+);
+
+const DANGER_RIVER_TILES = mergeSets(RIVER_TILES, CASTLE_RIVER_TILES);
+
 export default function Celula({
   coords,
   jogador,
   objetivo,
-  obst,
+  obstMap,
   reiniciarJogo,
-  LamaCapim,
+  terrenosMap,
 }) {
-  let bloco = "";
-  let ponte = "";
-  let objetivoComp = "";
-  let personagem = "";
-  let casaCastelo = "";
+  const [x, y] = coords;
+  const cellKey = coordKey(x, y);
+  const obstaculos = obstMap ?? new Map();
+  const terrenos = terrenosMap ?? new Map();
 
-  // Função auxiliar para gerar coordenadas
-  const gerarCoords = (xIni, xFim, yIni, yFim) => {
-    const arr = [];
-    for (let i = xIni; i < xFim; i++) {
-      for (let j = yIni; j < yFim; j++) {
-        arr.push([i, j]);
-      }
-    }
-    return arr;
-  };
+  const objetivoKey =
+    objetivo && objetivo.length === 2 && objetivo[0] != null
+      ? coordKey(objetivo[0], objetivo[1])
+      : null;
+  const jogadorKey =
+    jogador && jogador.length === 2 && jogador[0] != null
+      ? coordKey(jogador[0], jogador[1])
+      : null;
 
-  const rio = gerarCoords(0, 10, 0, 12);
-  const rioCastelo = [
-    ...gerarCoords(5, 10, 10, 23),
-    ...gerarCoords(5, 10, 27, 48),
-  ];
+  const blocoOcupado = STATIC_BLOCKERS.has(cellKey) || obstaculos.has(cellKey);
 
-  const caminhos = gerarCoords(5, 10, 23, 24);
-  const caminhos2 = gerarCoords(5, 10, 24, 26);
-  const caminhos3 = gerarCoords(5, 10, 26, 27);
+  let bloco = null;
+  let ponte = null;
+  let objetivoComp = null;
+  let personagem = null;
+  let casaCastelo = null;
 
-  const posicaoArvores = [
-    ...gerarCoords(0, 3, 10, 80),
-    ...gerarCoords(10, 80, 0, 3),
-  ];
-
-  const posicaoArvores3 = gerarCoords(10, 48, 3, 10);
-
-  const posicaoArvores2 = [
-    ...gerarCoords(48, 80, 0, 50),
-    ...gerarCoords(0, 50, 48, 80),
-  ];
-
-  const posicaoCastelo1 = [[4, 24]];
-  const posicaoCastelo2 = [[3, 24]];
-  const posicaoCastelo3 = [[4, 25]];
-  const posicaoCastelo4 = [[3, 25]];
-
-  const placa = [10, 22];
-
-  const todosOsObstaculos = [
-    ...obst,
-    ...posicaoArvores,
-    ...posicaoArvores2,
-    ...posicaoArvores3,
-    ...posicaoCastelo1,
-    ...posicaoCastelo2,
-    ...posicaoCastelo3,
-    ...posicaoCastelo4,
-    ...rio,
-    ...rioCastelo,
-    ...caminhos,
-    ...caminhos2,
-    ...caminhos3,
-    placa,
-  ];
-
-  const obstaculoNoCaminho = todosOsObstaculos.some(
-    (pos) => pos[0] === coords[0] && pos[1] === coords[1]
-  );
-
-  // Renderiza objetivo
-  if (
-    coords[0] === objetivo[0] &&
-    coords[1] === objetivo[1] &&
-    !obstaculoNoCaminho
-  ) {
+  if (objetivoKey && cellKey === objetivoKey && !blocoOcupado) {
     objetivoComp = <Objetivo />;
   }
 
-  // Renderiza personagem
-  if (coords[0] === jogador[0] && coords[1] === jogador[1]) {
+  if (jogadorKey && cellKey === jogadorKey) {
     personagem = <Personagem />;
 
-    if (
-      jogador[0] === objetivo[0] &&
-      jogador[1] === objetivo[1] &&
-      obstaculoNoCaminho
-    ) {
+    if (objetivoKey && jogadorKey === objetivoKey && blocoOcupado) {
       reiniciarJogo();
     }
 
-    if (
-      rio.some((pos) => pos[0] === jogador[0] && pos[1] === jogador[1]) ||
-      rioCastelo.some(
-        (pos) => pos[0] === jogador[0] && pos[1] === jogador[1]
-      )
-    ) {
+    if (DANGER_RIVER_TILES.has(jogadorKey)) {
       reiniciarJogo();
     }
   }
 
-  // Verifica obstáculos
-  const obstaculoAtual = obst.find(
-    (pos) => pos[0] === coords[0] && pos[1] === coords[1]
-  );
-
-  const LamaCapimAtual = LamaCapim.find(
-    (pos) => pos[0] === coords[0] && pos[1] === coords[1]
-  );
-
-  if (obstaculoAtual) {
-    switch (obstaculoAtual[2]) {
+  const obstaculoTipo = obstaculos.get(cellKey);
+  if (obstaculoTipo) {
+    switch (obstaculoTipo) {
       case 1:
-        bloco = <div className="arvore2" key="arvore2"></div>;
+        bloco = <div className="arvore2" key="arvore2" />;
         break;
       case 2:
-        bloco = <div className="pedra" key="pedra"></div>;
+        bloco = <div className="pedra" key="pedra" />;
+        break;
+      default:
         break;
     }
   }
 
-  if (LamaCapimAtual) {
-    switch (LamaCapimAtual[2]) {
+  const terrenoTipo = terrenos.get(cellKey);
+  if (terrenoTipo) {
+    switch (terrenoTipo) {
       case 1:
-        bloco = <div className="lama" key="lama"></div>;
+        bloco = <div className="lama" key="lama" />;
         break;
       case 2:
-        bloco = <div className="capim" key="capim"></div>;
+        bloco = <div className="capim" key="capim" />;
+        break;
+      default:
         break;
     }
   }
 
-  // Checagem de terrenos e construções
-  if (rio.some((pos) => pos[0] === coords[0] && pos[1] === coords[1])) {
-    bloco = <div className="rio" key="rio"></div>;
-  } else if (
-    caminhos.some((pos) => pos[0] === coords[0] && pos[1] === coords[1])
-  ) {
-    ponte = <div className="ponte1" key="ponte1"></div>;
-  } else if (
-    caminhos2.some((pos) => pos[0] === coords[0] && pos[1] === coords[1])
-  ) {
-    ponte = <div className="ponte2" key="ponte2"></div>;
-  } else if (
-    caminhos3.some((pos) => pos[0] === coords[0] && pos[1] === coords[1])
-  ) {
-    ponte = <div className="ponte3" key="ponte3"></div>;
-  } else if (
-    posicaoArvores.some((pos) => pos[0] === coords[0] && pos[1] === coords[1])
-  ) {
-    bloco = <div className="arvore" key="arvore1"></div>;
-  } else if (
-    posicaoArvores2.some((pos) => pos[0] === coords[0] && pos[1] === coords[1])
-  ) {
-    bloco = <div className="arvore" key="arvore2"></div>;
-  } else if (
-    posicaoArvores3.some((pos) => pos[0] === coords[0] && pos[1] === coords[1])
-  ) {
-    bloco = <div className="arvore" key="arvore3"></div>;
+  if (RIVER_TILES.has(cellKey) || CASTLE_RIVER_TILES.has(cellKey)) {
+    bloco = <div className="rio" key="rio" />;
+  } else if (PATH_TILE_CLASS.has(cellKey)) {
+    const ponteClasse = PATH_TILE_CLASS.get(cellKey);
+    ponte = <div className={ponteClasse} key={ponteClasse} />;
+  } else if (TREE_TILES.has(cellKey)) {
+    bloco = <div className="arvore" key="arvore" />;
   }
 
-  if (posicaoCastelo1.some((pos) => pos[0] === coords[0] && pos[1] === coords[1])) {
-    casaCastelo = <div className="castelo1" key="castelo1"></div>;
-  } else if (posicaoCastelo2.some((pos) => pos[0] === coords[0] && pos[1] === coords[1])) {
-    casaCastelo = <div className="castelo2" key="castelo2"></div>;
-  } else if (posicaoCastelo3.some((pos) => pos[0] === coords[0] && pos[1] === coords[1])) {
-    casaCastelo = <div className="castelo3" key="castelo3"></div>;
-  } else if (posicaoCastelo4.some((pos) => pos[0] === coords[0] && pos[1] === coords[1])) {
-    casaCastelo = <div className="castelo4" key="castelo4"></div>;
+  if (CASTLE_TILES.has(cellKey)) {
+    const castleClass = CASTLE_TILES.get(cellKey);
+    casaCastelo = <div className={castleClass} key={castleClass} />;
   }
 
-  if (rioCastelo.some((pos) => pos[0] === coords[0] && pos[1] === coords[1])) {
-    bloco = <div className="rio" key="rio2"></div>;
-  }
-
-  if (placa[0] === coords[0] && placa[1] === coords[1]) {
-    bloco = <div className="placa" key="placa"></div>;
+  if (cellKey === SIGN_TILE_KEY) {
+    bloco = <div className="placa" key="placa" />;
   }
 
   return (


### PR DESCRIPTION
## Summary
- refactor the RepGame controller to validate moves, block premature castle entry, and provide progress messaging with a reusable restart flow
- restyle the HUD, start, and victory screens for a more immersive presentation and add an interactive status panel with goal distance feedback
- refresh board, cell, and character styling to add animations, hover reactions, and consistent board framing

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e5ac7aaf2883249f0c3785cf24c15c