### PR TITLE
Darken maze backdrop and increase zoom

### DIFF
--- a/app/jogo/Styles/StyleTabuleiro.css
+++ b/app/jogo/Styles/StyleTabuleiro.css
@@ -2,16 +2,18 @@ html,
 body {
   padding: 0;
   margin: 0;
+  background-color: #0d0d0f;
+  color: #f5f5f5;
 }
 
 :root {
   --board-columns: 50;
-  --base-cell-size: 20px;
+  --base-cell-size: clamp(45px, 9vmin, 110px);
 }
 
 .container {
-  --board-horizontal-limit: max(0px, calc(100vw - 32px));
-  --board-vertical-limit: max(0px, calc(100vh - 120px));
+  --board-horizontal-limit: max(0px, calc(100vw - 12px));
+  --board-vertical-limit: max(0px, calc(100vh - 40px));
   --cell-size: min(
     var(--base-cell-size),
     calc(var(--board-horizontal-limit) / var(--board-columns)),


### PR DESCRIPTION
## Summary
- darken the page backdrop so white margins around the board appear black instead
- raise the base cell clamp to zoom further into each maze tile

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68e9c8ae3af88324a9d31d669c35b4d5