### PR TITLE
Adjust board scaling and add scroll container

### DIFF
--- a/app/jogo/Styles/StyleTabuleiro.css
+++ b/app/jogo/Styles/StyleTabuleiro.css
@@ -9,17 +9,20 @@ body {
   --base-cell-size: 20px;
 }
 
+.board-scroll-container {
+  max-width: calc(100vw - 64px);
+  max-height: calc(100vh - 64px);
+  overflow: auto;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin: 0 auto;
+}
+
 .container {
-  --board-horizontal-limit: max(0px, calc(100vw - 32px));
-  --board-vertical-limit: max(0px, calc(100vh - 120px));
-  --cell-size: min(
-    var(--base-cell-size),
-    calc(var(--board-horizontal-limit) / var(--board-columns)),
-    calc(var(--board-vertical-limit) / var(--board-columns))
-  );
+  --cell-size: var(--base-cell-size);
   width: calc(var(--cell-size) * var(--board-columns));
   height: calc(var(--cell-size) * var(--board-columns));
-  margin: 0 auto;
   display: flex;
   flex-direction: column;
 }

--- a/app/jogo/Tabuleiro.jsx
+++ b/app/jogo/Tabuleiro.jsx
@@ -17,23 +17,25 @@ export default function Tabuleiro({
   );
 
   return (
-    <div className="container">
-      {celula.map((linha, i) => {
-        const temp = linha.map((coluna, j) => {
-          return (
-            <Celula
-              key={`${i}-${j}`}
-              coords={[i, j]}
-              jogador={jogador}
-              objetivo={obj}
-              obst={obst}
-              reiniciarJogo={reiniciarJogo}
-              LamaCapim={LamaCapim}
-            />
-          );
-        });
-        return <div key={i} className="mostralinha">{temp}</div>;
-      })}
+    <div className="board-scroll-container">
+      <div className="container">
+        {celula.map((linha, i) => {
+          const temp = linha.map((coluna, j) => {
+            return (
+              <Celula
+                key={`${i}-${j}`}
+                coords={[i, j]}
+                jogador={jogador}
+                objetivo={obj}
+                obst={obst}
+                reiniciarJogo={reiniciarJogo}
+                LamaCapim={LamaCapim}
+              />
+            );
+          });
+          return <div key={i} className="mostralinha">{temp}</div>;
+        })}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- set the board cell size to use the configured base value without viewport constraints
- wrap the board in a scrollable container so larger grids can be navigated

## Testing
- not run (UI-only changes)


------
https://chatgpt.com/codex/tasks/task_b_68ea3ddc9220832494dc5680f56af100