### PR TITLE
Keep player focused and centered in board

### DIFF
--- a/app/jogo/RepGame.jsx
+++ b/app/jogo/RepGame.jsx
@@ -1,5 +1,5 @@
 "use client";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import "./Styles/StyleRepGame.css";
 import Tabuleiro from "./Tabuleiro";
 import {
@@ -30,6 +30,8 @@ export default function RepGame() {
   const [gameStatus, setGameStatus] = useState(INITIAL_GAME_STATUS);
   const [seed, setSeed] = useState(0);
   const [showGateWarning, setShowGateWarning] = useState(false);
+  const boardContainerRef = useRef(null);
+  const playerCellRef = useRef(null);
 
   useEffect(() => {
     const forbidden = new Set();
@@ -92,6 +94,35 @@ export default function RepGame() {
     setPlayer(null);
     setSeed((value) => value + 1);
   }, []);
+
+  useEffect(() => {
+    if (!player) {
+      return;
+    }
+
+    const container = boardContainerRef.current;
+    const cell = playerCellRef.current;
+
+    if (!container || !cell) {
+      return;
+    }
+
+    const containerRect = container.getBoundingClientRect();
+    const cellRect = cell.getBoundingClientRect();
+
+    const offsetTop = cellRect.top - containerRect.top + container.scrollTop;
+    const offsetLeft = cellRect.left - containerRect.left + container.scrollLeft;
+
+    container.scrollTo({
+      top: offsetTop - container.clientHeight / 2 + cell.offsetHeight / 2,
+      left: offsetLeft - container.clientWidth / 2 + cell.offsetWidth / 2,
+      behavior: "smooth",
+    });
+
+    if (typeof cell.focus === "function") {
+      cell.focus({ preventScroll: true });
+    }
+  }, [player]);
 
   useEffect(() => {
     if (!showGateWarning) {
@@ -199,6 +230,8 @@ export default function RepGame() {
           obst={obstacles}
           reiniciarJogo={reiniciarJogo}
           LamaCapim={lamaCapim}
+          boardRef={boardContainerRef}
+          playerCellRef={playerCellRef}
         />
       )}
 

--- a/app/jogo/Styles/StyleTabuleiro.css
+++ b/app/jogo/Styles/StyleTabuleiro.css
@@ -24,6 +24,26 @@ body {
   flex-direction: column;
 }
 
+.tabuleiro-scroll {
+  --board-horizontal-limit: max(0px, calc(100vw - 32px));
+  --board-vertical-limit: max(0px, calc(100vh - 120px));
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 16px;
+  border-radius: 28px;
+  background: rgba(6, 10, 18, 0.55);
+  box-shadow: 0 18px 38px rgba(3, 6, 12, 0.6);
+  overflow: auto;
+  max-width: var(--board-horizontal-limit);
+  max-height: var(--board-vertical-limit);
+  backdrop-filter: blur(6px);
+}
+
+.tabuleiro-scroll:focus-within {
+  box-shadow: 0 18px 42px rgba(18, 120, 255, 0.35);
+}
+
 .mostralinha {
   display: flex;
   flex-direction: row;

--- a/app/jogo/Tabuleiro.jsx
+++ b/app/jogo/Tabuleiro.jsx
@@ -9,6 +9,8 @@ export default function Tabuleiro({
   obst,
   reiniciarJogo,
   LamaCapim,
+  boardRef,
+  playerCellRef,
 }) {
   const [celula, setCelula] = useState(
     Array(50)
@@ -17,23 +19,28 @@ export default function Tabuleiro({
   );
 
   return (
-    <div className="container">
-      {celula.map((linha, i) => {
-        const temp = linha.map((coluna, j) => {
-          return (
-            <Celula
-              key={`${i}-${j}`}
-              coords={[i, j]}
-              jogador={jogador}
-              objetivo={obj}
-              obst={obst}
-              reiniciarJogo={reiniciarJogo}
-              LamaCapim={LamaCapim}
-            />
-          );
-        });
-        return <div key={i} className="mostralinha">{temp}</div>;
-      })}
+    <div className="tabuleiro-scroll" ref={boardRef}>
+      <div className="container">
+        {celula.map((linha, i) => {
+          const temp = linha.map((coluna, j) => {
+            const isPlayerCell = jogador[0] === i && jogador[1] === j;
+
+            return (
+              <Celula
+                key={`${i}-${j}`}
+                coords={[i, j]}
+                jogador={jogador}
+                objetivo={obj}
+                obst={obst}
+                reiniciarJogo={reiniciarJogo}
+                LamaCapim={LamaCapim}
+                focusRef={isPlayerCell ? playerCellRef : undefined}
+              />
+            );
+          });
+          return <div key={i} className="mostralinha">{temp}</div>;
+        })}
+      </div>
     </div>
   );
 }

--- a/app/jogo/celula.jsx
+++ b/app/jogo/celula.jsx
@@ -2,7 +2,15 @@ import Objetivo from "./Objetivo";
 import Personagem from "./Personagem";
 import "./Styles/StyleCelula.css";
 
-export default function Celula({coords,jogador,objetivo,obst,reiniciarJogo,LamaCapim,}) {
+export default function Celula({
+  coords,
+  jogador,
+  objetivo,
+  obst,
+  reiniciarJogo,
+  LamaCapim,
+  focusRef,
+}) {
   let bloco = "";
   let ponte = "";
   let obj = "";
@@ -145,8 +153,15 @@ export default function Celula({coords,jogador,objetivo,obst,reiniciarJogo,LamaC
     bloco = <div className="placa" key="placa"></div>;
   }
 
+  const isPlayerCell = coords[0] === jogador[0] && coords[1] === jogador[1];
+
   return (
-    <div className="Celula">
+    <div
+      className="Celula"
+      ref={focusRef}
+      tabIndex={isPlayerCell ? -1 : undefined}
+      aria-label={isPlayerCell ? "Posição atual do jogador" : undefined}
+    >
       {bloco}
       {ponte}
       {casaCastelo}


### PR DESCRIPTION
## Summary
- wrap the maze board with a scrollable container that preserves the dark backdrop styling
- track the board and player cell with refs so the viewport recenters and stays focused on the hero as they move
- expose focusable player cells to keep keyboard focus synced with the current position

## Testing
- npm run lint *(fails: command prompts for interactive ESLint setup in this environment)*

------
https://chatgpt.com/codex/tasks/task_b_68ea3ddce8388324a2c0b521485d2fe4